### PR TITLE
Remove trailing whitespace from files

### DIFF
--- a/README-CHERI.md
+++ b/README-CHERI.md
@@ -1,6 +1,6 @@
 ### Compilation:
   - ifdef's: to enable trace generation for simulation, +define+RVFI. no other ifdef's needed
-  - top-level design: ibex_top_tracing 
+  - top-level design: ibex_top_tracing
 
 ### List of design files
 
@@ -40,7 +40,7 @@ Core RTL files:
 To compile a simple top-level (without security options), use
 -  $rtl/ibexc_top.sv
 -  $rtl/ibexc_top_tracing.sv
-  
+
 To compile the full ibex top-level, use
 - $rtl/ibex_core.sv
 - $rtl/ibex_lockstep.sv
@@ -52,7 +52,7 @@ To compile the full ibex top-level, use
 
 
 ### Dependencies
--  dv_fcov_macros.svh 
+-  dv_fcov_macros.svh
 -  prim_cipher_pkg.sv
 -  prim_lfsr.sv
 -  prim_ram_1p_pkg.sv

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Exceptions are generated in the case of access rule violations.
 
 The cheriot-ibex CLC implementation provides an optional load-filter feature. When enabled (cheri_tsafe_en_i == 1), the CLC instruction checks a memory area which contains shadow bits for the heap memory data at 8-byte granularity. The tag bit of the loaded capability is cleared if the corresponding shadow bits == 1 (revoked). The shadow bits are accessed through a dedicated memory interface (tsmap_*).
 
-## Integrated hardware accelerators 
+## Integrated hardware accelerators
 
 When configured accordingly, cheriot-ibex contains 2 internal tightly-coupled hardware accelerators,
 - The background revocation engine (TBRE). The TBRE engine is controlled by a memory-mapped registor interface. When activated, the engine scans a designated memory region and check all capabilities stored in the region against the revocation shadowbits area. If a match is found, the tag of the capability is cleared and stored back to the same memory location.
 - The stack zerorization engine (STKZ). The STKZ engine is controlled by the special capability register ZTOPC. The STKZ is used to zeroize a (stack) memory region as specified by ZTOPC, in order to facilitate context switching.
-  
+
 Note that the main CPU pipeline, TBRE and STKZ all use the load-store unit to access the data memory space. The priorities in the case of contention are,
 1. CPU pipeline (highest priority)
 2. STKZ
@@ -116,9 +116,9 @@ To debug capability-related software issues, cheriot-ibex also provides a debug 
 
 ## Timing, area and power
 
-A PPA study conducted at Microsoft shows that cheriot-ibex is similar to the original ibex design in terms of area and power, however with moderate increase in area. 
+A PPA study conducted at Microsoft shows that cheriot-ibex is similar to the original ibex design in terms of area and power, however with moderate increase in area.
 
-cheriot-ibex (configured as 3-stage pipeline) has been synthesized successfully using Synopsys DC-topo at 250MHz using TSMC 28nm (28LP) libraries (ss 1.03v) and 550MHz using TSMC 5nm (N5) libraries (ss 0.6v). Timing is mostly limited by TCM read access time (which approaches 1.6ns in the N5 case). 
+cheriot-ibex (configured as 3-stage pipeline) has been synthesized successfully using Synopsys DC-topo at 250MHz using TSMC 28nm (28LP) libraries (ss 1.03v) and 550MHz using TSMC 5nm (N5) libraries (ss 0.6v). Timing is mostly limited by TCM read access time (which approaches 1.6ns in the N5 case).
 
 The design area is ~60k gate equivalents (~25% more the original ibex design). Both dynamic and leakage power are shown as similar to the original ibex design.
 
@@ -126,5 +126,4 @@ The design area is ~60k gate equivalents (~25% more the original ibex design). B
 ## Build the design for simulation and emulation
 See [README-CHERI.md](https://github.com/microsoft/cheriot-ibex/blob/main/README-CHERI.md) for the list of RTL files need to compile/simulate/synthesize the cheriot_ibex design.
 
-In addition, [cheriot-safe](https://github.com/microsoft/cheriot-safe) provides an open-source FPGA platform for emulation and prototyping. 
-
+In addition, [cheriot-safe](https://github.com/microsoft/cheriot-safe) provides an open-source FPGA platform for emulation and prototyping.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,16 +10,16 @@
 
 # Support
 
-## How to file issues and get help  
+## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing
+issues before filing new issues to avoid duplicates.  For new issues, file your bug or
 feature request as a new Issue.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
+For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE
 FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
 CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
 
-## Microsoft Support Policy  
+## Microsoft Support Policy
 
 Support for this **PROJECT or PRODUCT** is limited to the resources listed above.

--- a/dv/cheriot/README.md
+++ b/dv/cheriot/README.md
@@ -1,4 +1,4 @@
-This is the experimental cheriot verification setup. The idea is to 
+This is the experimental cheriot verification setup. The idea is to
   - use a CHERIoT-aware tool (TestRIG-like) to generate a (constrained) random instruction stream
   - execute the instruction stream with both cheriot-sail and cheriot-ibex RTL & testbench
   - Compare the trace file from sail and ibex
@@ -11,15 +11,15 @@ Currently we support the following RTL simulation setups
     - cd run/
     - ./vgen
     - ./vcomp
-    - ./obj_dir/Vtb_cheriot_top input_file 
+    - ./obj_dir/Vtb_cheriot_top input_file
   - VCS with a instruction stream file
     - cd run/
     - ./vcscomp           &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; // ./bin/instr_stream.vhx contains the pre-generated instruction stream
     - ./simv
   - VCS with an ELF
-    - ./vcscomp2          
+    - ./vcscomp2
     - ./simv              &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; // ./bin/instr_mem.vhx contains the pre-generated memory image
-   
+
 scripts/compare_trace.py is a python script which can be used to compare ibex and sail trace files
   - ../scripts/compare_trace.py ibex_trace_file_Name sail_trace_file_name
 

--- a/dv/cheriot/tb/core_ibex_fcov_if.sv
+++ b/dv/cheriot/tb/core_ibex_fcov_if.sv
@@ -85,7 +85,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 
   always_comb begin
     int i;
-    for (i=0;i<32;i++) 
+    for (i=0;i<32;i++)
       if ((cheri_ops >> i) & 1) fcov_cheri_instr = cheri_op_e'(i);
   end
 
@@ -156,7 +156,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
         id_instr_category = InstrCategoryCheriBounds;
       cheri_ops[CCLEAR_TAG], cheri_ops[CMOVE_CAP], cheri_ops[CSEAL], cheri_ops[CUNSEAL], cheri_ops[CAND_PERM]:
         id_instr_category = InstrCategoryCheriMod;
-      cheri_ops[CGET_PERM], cheri_ops[CGET_TYPE], cheri_ops[CGET_BASE], cheri_ops[CGET_TOP], cheri_ops[CGET_LEN], 
+      cheri_ops[CGET_PERM], cheri_ops[CGET_TYPE], cheri_ops[CGET_BASE], cheri_ops[CGET_TOP], cheri_ops[CGET_LEN],
       cheri_ops[CGET_TAG], cheri_ops[CGET_ADDR], cheri_ops[CSUB_CAP], cheri_ops[CIS_SUBSET], cheri_ops[CIS_EQUAL]:
         id_instr_category = InstrCategoryCheriQuery;
       // cheri_ops[CJAL]:
@@ -444,7 +444,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
   logic lockstep_glitch_err;
 
   logic fcov_tag_clear_cs1cd;
-  assign fcov_tag_clear_cs1cd = g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid & 
+  assign fcov_tag_clear_cs1cd = g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid &
                                ~g_cheri_ex.u_cheri_ex.result_cap_o.valid;
 
   covergroup uarch_cg @(posedge clk_i);
@@ -690,7 +690,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       // illegal_bins illegal = binsof(cp_misaligned_first_data_bus_err) intersect {1'b1} &&
       //  binsof(cp_misaligned_second_data_bus_err) intersect {1'b1};
    // }
-    
+
     //
     // New coverage points
     //
@@ -709,8 +709,8 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       bins bin8to14 = {[8:14]};
       bins bin15    = {15};
     }
- 
-    cp_rd_addr:  coverpoint id_stage_i.rf_waddr_id_o[3:0] iff 
+
+    cp_rd_addr:  coverpoint id_stage_i.rf_waddr_id_o[3:0] iff
                  (id_stage_i.rf_we_id_o | g_cheri_ex.u_cheri_ex.cheri_rf_we_o) {
       bins bin0     = {0};
       bins bin1to7  = {[1:7]};
@@ -719,8 +719,8 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     }
 
     // all CHERIoT instructions enumerated
-    cp_cheri_instr_set: coverpoint fcov_cheri_instr iff (|cheri_ops); 
-     
+    cp_cheri_instr_set: coverpoint fcov_cheri_instr iff (|cheri_ops);
+
     // coverage points for PCC
     cp_pcc_tag: coverpoint cs_registers_i.pcc_cap_o.valid;
 
@@ -736,13 +736,13 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       bins bin1 = {[1:7]};
     }
 
-    cp_pcc_perm_ex: coverpoint cs_registers_i.pcc_cap_o.perms[PERM_EX] iff 
+    cp_pcc_perm_ex: coverpoint cs_registers_i.pcc_cap_o.perms[PERM_EX] iff
                               (cs_registers_i.pcc_cap_o.valid);
 
     // coverage points for CS1
     cp_cs1_tag: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid;
 
-    cp_cs1_exp: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.exp iff 
+    cp_cs1_exp: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.exp iff
                           (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
       bins bin0 = {0};
       bins bin1 = {[1:14]};
@@ -750,84 +750,84 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       illegal_bins illegal = default;
     }
 
-    cp_cs1_otype: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.otype iff 
+    cp_cs1_otype: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.otype iff
                             (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
       bins bin[] = {[0:7]};    // including reserved values for coverage
     }
 
-    cp_cs1_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_a.base_cor, 
-                            g_cheri_ex.u_cheri_ex.rf_fullcap_a.top_cor} iff 
+    cp_cs1_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_a.base_cor,
+                            g_cheri_ex.u_cheri_ex.rf_fullcap_a.top_cor} iff
                             (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
+      bins bin0 = {4'b0000};
+      bins bin1 = {4'b0001};
       // bins bin2 = {4'b0011}; // base_cor = 0, top_cor = -1, impossible case
-      bins bin3 = {4'b1100}; 
+      bins bin3 = {4'b1100};
       // bins bin4 = {4'b1101};    // impossible case
       // bins bin5 = {4'b1111};    // impossible case
       illegal_bins illegal = default;
     }
 
-    cp_cs1_top: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.top iff 
+    cp_cs1_top: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.top iff
                             (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
       bins bin_all1 = {9'h1ff};
       bins bin_all0 = {9'h0};
       bins bin1     = {[9'h1:9'h1fe]};
     }
 
-    cp_cs1_base: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.base iff 
+    cp_cs1_base: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.base iff
                            (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
       bins bin_all1 = {9'h1ff};
       bins bin_all0 = {9'h0};
       bins bin1     = {[9'h1:9'h1fe]};
     }
 
-    cp_cs1_perms: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.perms iff 
+    cp_cs1_perms: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.perms iff
                             (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid) {
-      wildcard bins gl0  = {13'b?_????_????_???0}; 
+      wildcard bins gl0  = {13'b?_????_????_???0};
       wildcard bins gl1  = {13'b?_????_????_???1};
       wildcard bins lg0  = {13'b?_????_????_??0?};
       wildcard bins lg1  = {13'b?_????_????_??1?};
       wildcard bins sd0  = {13'b?_????_????_?0??};
       wildcard bins sd1  = {13'b?_????_????_?1??};
-      wildcard bins lm0  = {13'b?_????_????_0???}; 
+      wildcard bins lm0  = {13'b?_????_????_0???};
       wildcard bins lm1  = {13'b?_????_????_1???};
-      wildcard bins sl0  = {13'b?_????_???0_????}; 
+      wildcard bins sl0  = {13'b?_????_???0_????};
       wildcard bins sl1  = {13'b?_????_???1_????};
-      wildcard bins ld0  = {13'b?_????_??0?_????}; 
+      wildcard bins ld0  = {13'b?_????_??0?_????};
       wildcard bins ld1  = {13'b?_????_??1?_????};
-      wildcard bins mc0  = {13'b?_????_?0??_????}; 
+      wildcard bins mc0  = {13'b?_????_?0??_????};
       wildcard bins mc1  = {13'b?_????_?1??_????};
-      wildcard bins sr0  = {13'b?_????_0???_????}; 
+      wildcard bins sr0  = {13'b?_????_0???_????};
       wildcard bins sr1  = {13'b?_????_1???_????};
-      wildcard bins ex0  = {13'b?_???0_????_????}; 
+      wildcard bins ex0  = {13'b?_???0_????_????};
       wildcard bins ex1  = {13'b?_???1_????_????};
-      wildcard bins us0  = {13'b?_??0?_????_????}; 
+      wildcard bins us0  = {13'b?_??0?_????_????};
       wildcard bins us1  = {13'b?_??1?_????_????};
-      wildcard bins se0  = {13'b?_?0??_????_????}; 
+      wildcard bins se0  = {13'b?_?0??_????_????};
       wildcard bins se1  = {13'b?_?1??_????_????};
-      wildcard bins u00  = {13'b?_0???_????_????}; 
+      wildcard bins u00  = {13'b?_0???_????_????};
       wildcard bins u01  = {13'b?_1???_????_????};
-      wildcard bins u10  = {13'b0_????_????_????}; 
+      wildcard bins u10  = {13'b0_????_????_????};
       wildcard ignore_bins u11 = {13'b1_????_????_????};
       illegal_bins illegal = default;
     }
 
     cp_cd_tag: coverpoint g_cheri_ex.u_cheri_ex.result_cap_o.valid iff (g_cheri_ex.u_cheri_ex.cheri_rf_we_o);
 
-    cp_cd_cor: coverpoint {g_cheri_ex.u_cheri_ex.result_cap_o.base_cor, 
-                           g_cheri_ex.u_cheri_ex.result_cap_o.top_cor} iff 
+    cp_cd_cor: coverpoint {g_cheri_ex.u_cheri_ex.result_cap_o.base_cor,
+                           g_cheri_ex.u_cheri_ex.result_cap_o.top_cor} iff
                           (g_cheri_ex.u_cheri_ex.cheri_rf_we_o && g_cheri_ex.u_cheri_ex.result_cap_o.valid) {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
-      // bins bin2 = {4'b0011}; 
-      bins bin3 = {4'b1100}; 
-      // bins bin4 = {4'b1101}; 
-      // bins bin5 = {4'b1111}; 
+      bins bin0 = {4'b0000};
+      bins bin1 = {4'b0001};
+      // bins bin2 = {4'b0011};
+      bins bin3 = {4'b1100};
+      // bins bin4 = {4'b1101};
+      // bins bin5 = {4'b1111};
       illegal_bins illegal = default;
     }
 
     // addr/perm violations. this may cause either tag clearing or exception
-    cp_cheri_vio: coverpoint {g_cheri_ex.u_cheri_ex.perm_vio_vec, g_cheri_ex.u_cheri_ex.addr_bound_vio}  iff 
+    cp_cheri_vio: coverpoint {g_cheri_ex.u_cheri_ex.perm_vio_vec, g_cheri_ex.u_cheri_ex.addr_bound_vio}  iff
                             (g_cheri_ex.u_cheri_ex.cheri_exec_id_i) {
       wildcard bins bound = {10'b??_????_???1};
       wildcard bins tag   = {10'b??_????_??1?};
@@ -841,7 +841,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       wildcard bins slc   = {10'b1?_????_????};
     }
 
-    cp_tag_clear_cs1cd: coverpoint fcov_tag_clear_cs1cd iff 
+    cp_tag_clear_cs1cd: coverpoint fcov_tag_clear_cs1cd iff
                                          (g_cheri_ex.u_cheri_ex.cheri_exec_id_i);
 
     // coverage points for exception conditions
@@ -880,7 +880,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 
 
     cp_cheri_exception_reg_id: coverpoint g_cheri_ex.u_cheri_ex.cheri_wb_err_info_d[9:5] iff
-                          ((g_cheri_ex.u_cheri_ex.cheri_wb_err_d & !cheri_ops[CCSR_RW]) | 
+                          ((g_cheri_ex.u_cheri_ex.cheri_wb_err_d & !cheri_ops[CCSR_RW]) |
                           (g_cheri_ex.u_cheri_ex.lsu_req_o & g_cheri_ex.u_cheri_ex.lsu_cheri_err_o )) {
       wildcard illegal_bins illegal = {5'b1????} ;
     }
@@ -907,14 +907,14 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     cp_cpu_lsu_req: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_cpu_lsu_acc;
 
     cp_cpu_lsu_err: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_cpu_lsu_err;
- 
-    cp_lsu_xfer_size: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_ls_xfer_size iff 
+
+    cp_lsu_xfer_size: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_ls_xfer_size iff
                                  (g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_cpu_lsu_req) {
       bins good[] = {1, 2, 4, 8};
       illegal_bins illegal = default;
     }
 
-    cp_ls_room_cs1_chk: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_ls_cap_room_chk iff 
+    cp_ls_room_cs1_chk: coverpoint g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_ls_cap_room_chk iff
                                    (g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_cpu_lsu_req) {
       bins good[] = {0, 1};
       bins bad    = {2};
@@ -928,7 +928,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     cp_stkz_stall0: coverpoint g_cheri_ex.u_cheri_ex.cpu_stkz_stall0 iff
                                (g_cheri_ex.u_cheri_ex.cheri_ex_dv_ext_i.fcov_cpu_lsu_req);
 
-    cp_sktz_err: coverpoint g_cheri_ex.u_cheri_ex.cpu_stkz_err; 
+    cp_sktz_err: coverpoint g_cheri_ex.u_cheri_ex.cpu_stkz_err;
 
     cp_clsc_mem_err: coverpoint  load_store_unit_i.lsu_dv_ext_i.fcov_clsc_mem_err {
       illegal_bins illegal = {7};        // rsvd value
@@ -936,7 +936,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 
     cp_cheri_fetch_vio: coverpoint if_stage_i.cheri_acc_vio iff (if_stage_i.fetch_valid);
 
-    cp_trvk_addr: coverpoint g_trvk_stage.cheri_trvk_stage_i.rf_trvk_addr_o[3:0] iff 
+    cp_trvk_addr: coverpoint g_trvk_stage.cheri_trvk_stage_i.rf_trvk_addr_o[3:0] iff
                              (g_trvk_stage.cheri_trvk_stage_i.rf_trvk_en_o);
 
     cp_trvk_cond: coverpoint {g_trvk_stage.cheri_trvk_stage_i.trvk_status,
@@ -946,7 +946,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 
     cp_trvk_stall: coverpoint id_stage_i.stall_cheri_trvk;
 
-    cp_trvk_stall_cause: coverpoint id_stage_i.id_stage_dv_ext_i.fcov_trvk_stall_cause iff 
+    cp_trvk_stall_cause: coverpoint id_stage_i.id_stage_dv_ext_i.fcov_trvk_stall_cause iff
                                      (id_stage_i.stall_cheri_trvk) {
       wildcard bins cs1hz  = {3'b??1};
       wildcard bins cs2hz  = {3'b?1?};
@@ -971,12 +971,12 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       bins store2idle = (2 => 0);
       bins store2load = (2 => 1);
     }
-    
+
     // this equalss the tbre req fifo depth
     cp_tbre_os_cnt : coverpoint cheri_tbre_wrapper_i.g_tbre.cheri_tbre_i.os_req_cnt {
       bins normal[] = {[0:4]};
       illegal_bins illegal = default;
-    } 
+    }
 
     cp_tbre_fifo_hazard : coverpoint {cheri_tbre_wrapper_i.g_tbre.cheri_tbre_i.tbre_dv_ext_i.fcov_tbre_fifo_hazard,
                                      cheri_tbre_wrapper_i.g_tbre.cheri_tbre_i.tbre_dv_ext_i.fcov_tbre_fifo_head_hazard} {
@@ -986,7 +986,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 
     cp_tbre_mem_err: coverpoint cheri_tbre_wrapper_i.g_tbre.cheri_tbre_i.tbre_err_o;
 
-    cp_concur_mem_reqs: coverpoint {g_cheri_ex.u_cheri_ex.lsu_req_o, 
+    cp_concur_mem_reqs: coverpoint {g_cheri_ex.u_cheri_ex.lsu_req_o,
                                    cheri_tbre_wrapper_i.g_tbre.cheri_tbre_i.tbre_lsu_req_o,
                                    cheri_tbre_wrapper_i.g_stkz.cheri_stkz_i.stkz_lsu_req_o};
 
@@ -994,7 +994,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       bins good[]      = {[0:2]};
       illegal_bins bad = default;
     }
-   
+
     cp_stkz_ztop_wr: coverpoint cheri_tbre_wrapper_i.g_stkz.cheri_stkz_i.stkz_dv_ext_i.fcov_ztop_wr_type iff
                                 (cheri_tbre_wrapper_i.g_stkz.cheri_stkz_i.stkz_dv_ext_i.ztop_wr_i);
 
@@ -1035,7 +1035,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
 //         binsof(cp_ls_error_exception) intersect {1'b1});
 //    }
 
-    `define ListOfInstrRegOperands  {InstrCategoryALU, InstrCategoryMul, \ 
+    `define ListOfInstrRegOperands  {InstrCategoryALU, InstrCategoryMul, \
                                      InstrCategoryDiv, InstrCategoryBranch, \
                                      InstrCategoryJump, InstrCategoryLoad, \
                                      InstrCategoryStore, InstrCategoryCSRAccess, \
@@ -1065,7 +1065,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     }
 
     pipe_cross: cross cp_id_instr_category, cp_if_stage_state, cp_id_stage_state, cp_wb_stage_state {
-      // QQQ IF stage shouldn't be idle unless when sleep or reset 
+      // QQQ IF stage shouldn't be idle unless when sleep or reset
       // ignore_bins ignore = (!binsof(cp_id_instr_category) intersect {InstrCategoryWFI, InstrCategoryNone} &&
       ignore_bins ignore0 = ( binsof(cp_if_stage_state) intersect {IFStageEmptyAndIdle, IFStageFullAndIdle});
       // When ID stage is empty the only legal instruction category is InstrCategoryNone. Conversly
@@ -1074,10 +1074,10 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
       illegal_bins illegal0 = (!binsof(cp_id_instr_category) intersect {InstrCategoryNone} &&
         binsof(cp_id_stage_state) intersect {PipeStageEmpty}) ||
       (binsof(cp_id_instr_category) intersect {InstrCategoryNone} &&
-        !binsof(cp_id_stage_state) intersect {PipeStageEmpty}); 
+        !binsof(cp_id_stage_state) intersect {PipeStageEmpty});
       // Impossible to have a case where WB is stalled but ID is not
       illegal_bins illegal1 = (binsof(cp_id_stage_state) intersect {PipeStageFullAndUnstalled}) &&
-                              (binsof(cp_wb_stage_state) intersect {PipeStageFullAndStalled}); 
+                              (binsof(cp_wb_stage_state) intersect {PipeStageFullAndStalled});
     }
 
     // interrupt_taken_instr_cross: cross cp_nmi_taken, instr_unstalled_last,
@@ -1100,7 +1100,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
          binsof(cp_stall_type_id) intersect {IdStallTypeInstr})
     ||
         // Only ALU, Mul, Div, Branch, Jump, Load, Store and CSR Access can see a load hazard stall
-        (!binsof(cp_id_instr_category) intersect `ListOfInstrRegOperands && 
+        (!binsof(cp_id_instr_category) intersect `ListOfInstrRegOperands &&
          binsof(cp_stall_type_id) intersect {IdStallTypeLdHz});
 
       // Cannot have a memory stall when we see an LS exception unless it is a load or store
@@ -1136,7 +1136,7 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     dummy_instr_config_cross: cross cp_dummy_instr_type, cp_dummy_instr_mask
                                 iff (cs_registers_i.dummy_instr_en_o);
 
-    rf_ecc_err_cross: cross ibex_core_dv_ext_i.fcov_rf_ecc_err_a_id, 
+    rf_ecc_err_cross: cross ibex_core_dv_ext_i.fcov_rf_ecc_err_a_id,
                             ibex_core_dv_ext_i.fcov_rf_ecc_err_b_id
                                 iff (id_stage_i.instr_valid_i);
 
@@ -1153,10 +1153,10 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     //
     // CHERIoT cross coverage
     //
-    
+
     // cs1/cs2/cd cross. QQQ need to further cross with instr types.
     rs_rd_cross: cross cp_rs1_addr, cp_rs2_addr, cp_rd_addr;
-   
+
     // Cap manipulation and tag clearing
     //  QQQ CAUIPCC/CJAL/CJALR needs to be treated separately since it's from PCC, not cs1
     `define ListOfCs1CdInstr {CSEAL, CUNSEAL, CSET_ADDR, CINC_ADDR, \
@@ -1165,19 +1165,19 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     `define ListOfPcc2CdInstr {CAUIPCC, CJAL, CJALR}
 
     cheri_cs1cd_tag_cross: cross cp_cs1_tag, cp_cd_tag, cp_cheri_instr_set {
-      ignore_bins ignore0 = 
+      ignore_bins ignore0 =
         ((!binsof(cp_cheri_instr_set) intersect `ListOfCs1CdInstr) ||
-        ((binsof(cp_cs1_tag) intersect {1'b0}) && (binsof(cp_cd_tag) intersect {1'b0}))); 
-      illegal_bins illegal = 
+        ((binsof(cp_cs1_tag) intersect {1'b0}) && (binsof(cp_cd_tag) intersect {1'b0})));
+      illegal_bins illegal =
         ((binsof(cp_cs1_tag) intersect {1'b0}) && (binsof(cp_cd_tag) intersect {1'b1}) &&
          (binsof(cp_cheri_instr_set) intersect `ListOfCs1CdInstr));
     }
 
     cheri_pcc2cd_tag_cross: cross cp_pcc_tag, cp_cd_tag, cp_cheri_instr_set {
-      ignore_bins ignore0 = 
+      ignore_bins ignore0 =
         ((!binsof(cp_cheri_instr_set) intersect `ListOfPcc2CdInstr) ||
-        ((binsof(cp_pcc_tag) intersect {1'b0}))); 
-      illegal_bins illegal = 
+        ((binsof(cp_pcc_tag) intersect {1'b0})));
+      illegal_bins illegal =
         ((binsof(cp_pcc_tag) intersect {1'b0}) && (binsof(cp_cd_tag) intersect {1'b1}) &&
          (binsof(cp_cheri_instr_set) intersect `ListOfPcc2CdInstr)) ||
         ((binsof(cp_pcc_tag) intersect {1'b1}) && (binsof(cp_cd_tag) intersect {1'b0}) &&
@@ -1185,32 +1185,32 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; (
     }
 
     cheri_xfer_room_cross: cross cp_lsu_xfer_size, cp_ls_room_cs1_chk;
-    
+
     // non-load/store CHERI exceptions
     cheri_jump_exception_cross: cross cp_cheri_wb_exception_causes, cp_cheri_instr_set {
-      ignore_bins ignore0 = 
+      ignore_bins ignore0 =
         (!binsof(cp_cheri_instr_set) intersect {CJAL, CJALR}) ||
-        ((binsof(cp_cheri_instr_set) intersect {CJAL}) && (binsof(cp_cheri_wb_exception_causes) intersect {5'h2, 5'h3, 5'h11, 5'h18})) || 
-        ((binsof(cp_cheri_instr_set) intersect {CJALR}) && (binsof(cp_cheri_wb_exception_causes) intersect {5'h18}));  
+        ((binsof(cp_cheri_instr_set) intersect {CJAL}) && (binsof(cp_cheri_wb_exception_causes) intersect {5'h2, 5'h3, 5'h11, 5'h18})) ||
+        ((binsof(cp_cheri_instr_set) intersect {CJALR}) && (binsof(cp_cheri_wb_exception_causes) intersect {5'h18}));
     }
-    
+
     cheri_scr_exception_cross: cross cp_cheri_wb_exception_causes, cp_cheri_instr_set {
-      ignore_bins ignore0 = 
+      ignore_bins ignore0 =
         (!binsof(cp_cheri_instr_set) intersect {CCSR_RW}) ||
         (!binsof(cp_cheri_wb_exception_causes.perm_sr));
     }
-    
+
     // LSU access cross QQQ
 
     // IF fetch violation
     cheri_fetch_cross: cross cp_cheri_fetch_vio, cp_pcc_tag, cp_pcc_perm_ex, cp_pcc_otype {
-      illegal_bins illegal = (binsof(cp_cheri_fetch_vio) intersect {1'b0}) &&  
-                             ((binsof(cp_pcc_tag) intersect {1'b0})     || 
-                              (binsof(cp_pcc_perm_ex) intersect {1'b0}) || 
-                              (binsof(cp_pcc_otype) intersect {[1:7]})); 
+      illegal_bins illegal = (binsof(cp_cheri_fetch_vio) intersect {1'b0}) &&
+                             ((binsof(cp_pcc_tag) intersect {1'b0})     ||
+                              (binsof(cp_pcc_perm_ex) intersect {1'b0}) ||
+                              (binsof(cp_pcc_otype) intersect {[1:7]}));
     }
 
-    // trvk stall 
+    // trvk stall
     cheri_trvk_cross: cross cp_trvk_stall, cp_rd_a_hz, cp_rd_b_hz;
 
     // stkz ztop writes

--- a/dv/cheriot/tb/dii_if.sv
+++ b/dv/cheriot/tb/dii_if.sv
@@ -70,39 +70,39 @@ module dii_if (
 
     while (1) begin
       @(posedge clk_i);
-      if (dii_ack) 
+      if (dii_ack)
         hqueue = {hqueue, {dii_pc_o, dii_insn}};    // enqeue
 
       if (rvfi_valid) begin
-        assert (hqueue.size() >= 1) 
+        assert (hqueue.size() >= 1)
           else $error("dii_if: holding queue empty");
 
         if (~flush_active) begin
-          assert(hqueue[0] == {rvfi_pc, rvfi_insn}) 
+          assert(hqueue[0] == {rvfi_pc, rvfi_insn})
             else $error("dii_if: holding queue read mismatch");
-          hqueue = hqueue[1:$];     
+          hqueue = hqueue[1:$];
         end else begin  // exception entry found, flush holding queue
           flush_cnt  = 0;
           while (1) begin
             if (hqueue.size() == 0) break;
             if (hqueue[0] == {rvfi_pc, rvfi_insn}) begin
-              hqueue       = hqueue[1:$];     
+              hqueue       = hqueue[1:$];
               flush_active = 1'b0;
               break;
-            end else begin 
+            end else begin
               flush_cnt += 1;
-              hqueue = hqueue[1:$];     
+              hqueue = hqueue[1:$];
             end
-          end // while 
+          end // while
 
-          assert (!flush_active && (flush_cnt<=MaxFlushCnt)) 
+          assert (!flush_active && (flush_cnt<=MaxFlushCnt))
             else $error("dii_if: holding queue flush error");
         end
-        
-        // in ibex, only need to flush/resync the hqueue in the event of a WB-stage trap 
+
+        // in ibex, only need to flush/resync the hqueue in the event of a WB-stage trap
         if (rvfi_trap) flush_active = 1'b1;
       end
-  
+
     end
   end
 

--- a/dv/cheriot/tb/instr_mem_model.sv
+++ b/dv/cheriot/tb/instr_mem_model.sv
@@ -5,11 +5,11 @@
 //
 // instr interface/memory model
 //
-module instr_mem_model ( 
+module instr_mem_model (
   input  logic        clk,
   input  logic        rst_n,
 
-  input  logic [2:0]  ERR_RATE,    
+  input  logic [2:0]  ERR_RATE,
   input  logic [3:0]  GNT_WMAX,
   input  logic [3:0]  RESP_WMAX,
   input  logic        err_enable,
@@ -22,9 +22,9 @@ module instr_mem_model (
   output logic [31:0] instr_rdata,
   output logic        instr_err
 );
-  localparam int unsigned MEM_AW     = 16;  
-  localparam int unsigned MEM_DW     = 32; 
- 
+  localparam int unsigned MEM_AW     = 16;
+  localparam int unsigned MEM_DW     = 32;
+
   logic              mem_cs;
   logic [MEM_DW-1:0] mem_din;
   logic [MEM_DW-1:0] mem_rdata;
@@ -60,7 +60,7 @@ module instr_mem_model (
     .mem_rdata    (mem_rdata),
     .mem_err      (iram_err)
   );
- 
+
   //
   // memory signals (sampled @posedge clk)
   //
@@ -71,12 +71,12 @@ module instr_mem_model (
 
   assign iram_addr32 = mem_addr32[MEM_AW-1:0];
 
-  assign iram_err = iram_err_q && ((mem_addr32 < err_keepout_base[31:2]) || 
+  assign iram_err = iram_err_q && ((mem_addr32 < err_keepout_base[31:2]) ||
                                    (mem_addr32 > err_keepout_top[31:2]));
 
   always @(posedge clk) begin
     if (mem_cs)
-      mem_rdata <= iram[iram_addr32];  
+      mem_rdata <= iram[iram_addr32];
   end
 
   always @(negedge clk, negedge rst_n) begin
@@ -87,7 +87,7 @@ module instr_mem_model (
         iram_err_q <= err_enable & ((ERR_RATE == 0) ? 1'b0 : ($urandom()%(2**(8-ERR_RATE))==0));
 
     end
-  end 
- 
+  end
+
 
 endmodule

--- a/dv/cheriot/tb/intr_gen.sv
+++ b/dv/cheriot/tb/intr_gen.sv
@@ -30,7 +30,7 @@ module intr_gen (
     // irq state machine
     while (1) begin
       case (irq)
-        0: begin       
+        0: begin
           rand32 = $urandom();
           if (intr_en && (INTR_INTVL != 0)) begin
             nwait = ((rand32 % (2** INTR_INTVL)) + 1) * 10;   // wait at least 10 clk cycles
@@ -42,7 +42,7 @@ module intr_gen (
             @(posedge clk);
           end
         end
-        default: begin    // 
+        default: begin    //
           while (intr_ack == 0) @(posedge clk);
           rand32 = $urandom();
           if (rand32[31] | ~intr_en) begin
@@ -50,12 +50,12 @@ module intr_gen (
             //$display ("going irq=0 @%t", $time);
           end else begin
             // irq = rand32[15:0] % 7 + 1;   // back-to-back interrupts
-            irq = {2'b00, rand32[0]};  
+            irq = {2'b00, rand32[0]};
           end
           @(posedge clk);
         end
       endcase
-    end   
+    end
   end
 
 endmodule

--- a/dv/cheriot/tb/module_dv_ext.sv
+++ b/dv/cheriot/tb/module_dv_ext.sv
@@ -57,7 +57,7 @@ module ibex_id_stage_dv_ext (
 
   assign fcov_trvk_stall_cause[0] = rf_ren_a && ~rf_reg_rdy_i[rf_raddr_a_o];
   assign fcov_trvk_stall_cause[1] = rf_ren_b && ~rf_reg_rdy_i[rf_raddr_b_o];
-  assign fcov_trvk_stall_cause[2] = cheri_rf_we && ~rf_reg_rdy_i[rf_waddr_id_o]; 
+  assign fcov_trvk_stall_cause[2] = cheri_rf_we && ~rf_reg_rdy_i[rf_waddr_id_o];
 
 
 endmodule
@@ -122,8 +122,8 @@ module ibex_lsu_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
   input  logic         cheri_err_q,
   input  logic         resp_is_tbre_q,
   input  cap_rx_fsm_t  cap_rx_fsm_q,
-  input  logic         data_we_q,  
-  input  logic         cap_lsw_err_q  
+  input  logic         data_we_q,
+  input  logic         cap_lsw_err_q
 
 );
   // Set when awaiting the response for the second half of a misaligned access
@@ -191,11 +191,11 @@ module ibex_lsu_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
           fcov_clsc_mem_err = 3'h5;       // csc word 1 error only
        else if (~data_err_i & data_we_q & cap_lsw_err_q)
           fcov_clsc_mem_err = 3'h6;       // csc word 0 error only
-       else 
+       else
           fcov_clsc_mem_err = 3'h0;       // no error;
      end
    end
-    
+
 
 
 
@@ -210,7 +210,7 @@ module ibex_lsu_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
   `ASSERT_KNOWN(IbexDataTypeQKnown, data_type_q)
   `ASSERT(IbexLsuStateValid, ls_fsm_cs inside {
       IDLE, WAIT_GNT_MIS, WAIT_RVALID_MIS, WAIT_GNT,
-      WAIT_RVALID_MIS_GNTS_DONE, 
+      WAIT_RVALID_MIS_GNTS_DONE,
       CTX_WAIT_GNT1, CTX_WAIT_GNT2, CTX_WAIT_RESP})
 
   // Address must not contain X when request is sent.
@@ -242,8 +242,8 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
   input  logic [1:0]     rv32_lsu_type_i,
   input  logic           cheri_lsu_err,
   input  logic           rv32_lsu_err,
-  input  logic           lsu_req_o,   
-  input  logic           lsu_req_done_i,   
+  input  logic           lsu_req_o,
+  input  logic           lsu_req_done_i,
   input  logic [31:0]    cpu_lsu_addr,
   input  logic           cpu_lsu_we
   );
@@ -251,8 +251,8 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
   // assertion: STKZ active won't change in the middle of load/store (thus lsu_req will stay asserted till req_done)
   logic       outstanding_lsu_req;
 
-  typedef enum logic [3:0] {ACC_NULL, CAP_RD, CAP_WR, BYTE_RD, BYTE_WR, 
-                            HW_RD_ALIGNED, HW_RD_UNALIGNED, HW_WR_ALIGNED, HW_WR_UNALIGNED, 
+  typedef enum logic [3:0] {ACC_NULL, CAP_RD, CAP_WR, BYTE_RD, BYTE_WR,
+                            HW_RD_ALIGNED, HW_RD_UNALIGNED, HW_WR_ALIGNED, HW_WR_UNALIGNED,
                             WORD_RD_ALIGNED, WORD_RD_UNALIGNED, WORD_WR_ALIGNED, WORD_WR_UNALIGNED
                             } lsu_acc_type_e;
 
@@ -268,12 +268,12 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
         outstanding_lsu_req <= 1'b1;
     end
   end
-  `ASSERT(IbexLsuReqStable, (outstanding_lsu_req) |-> ($stable(pc_id_i) && $stable(instr_valid_i) && 
-                                                       $stable(cpu_lsu_we))) 
+  `ASSERT(IbexLsuReqStable, (outstanding_lsu_req) |-> ($stable(pc_id_i) && $stable(instr_valid_i) &&
+                                                       $stable(cpu_lsu_we)))
   // Cheri and RV32 LSU req can't both be active per decoder
-  `ASSERT(IbexLsuReqSrc, !(cheri_lsu_req & rv32_lsu_req_i)) 
+  `ASSERT(IbexLsuReqSrc, !(cheri_lsu_req & rv32_lsu_req_i))
 
-  // Functional coverage signals 
+  // Functional coverage signals
 
   `DV_FCOV_SIGNAL(logic, cpu_lsu_req, cheri_lsu_req | rv32_lsu_req_i);
   `DV_FCOV_SIGNAL(logic, cpu_lsu_err, (cheri_lsu_err | rv32_lsu_err) && (cheri_lsu_req | rv32_lsu_req_i));
@@ -304,7 +304,7 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
       fcov_cpu_lsu_acc = BYTE_RD;
     else if (rv32_lsu_req_i)
       fcov_cpu_lsu_acc = BYTE_WR;
-      
+
   end
 
   logic [3:0]  fcov_ls_xfer_size;
@@ -315,9 +315,9 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
     if (cheri_lsu_req)
       fcov_room_in_cs1_cap = u_cheri_ex.rf_fullcap_a.top33 - u_cheri_ex.cheri_ls_chkaddr;
     else if (rv32_lsu_req_i)
-      fcov_room_in_cs1_cap = u_cheri_ex.rf_fullcap_a.top33 - u_cheri_ex.rv32_ls_chkaddr + 
+      fcov_room_in_cs1_cap = u_cheri_ex.rf_fullcap_a.top33 - u_cheri_ex.rv32_ls_chkaddr +
                              {u_cheri_ex.addr_incr_req_i, 2'b00};
-    else 
+    else
       fcov_room_in_cs1_cap = 0;
 
     if (cheri_lsu_req)
@@ -331,7 +331,7 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
     else
       fcov_ls_xfer_size = 4'h0;
 
-    fcov_ls_cap_room_chk = (fcov_room_in_cs1_cap > fcov_ls_xfer_size) ? 0 : 
+    fcov_ls_cap_room_chk = (fcov_room_in_cs1_cap > fcov_ls_xfer_size) ? 0 :
                            (fcov_room_in_cs1_cap == fcov_ls_xfer_size)? 1 : 2;
   end
 
@@ -339,7 +339,7 @@ module cheri_ex_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
       (csr_op_o == CHERI_CSR_RW) && csr_access_o & ~csr_op_en_o & cheri_operator_i[CCSR_RW] & cheri_exec_id_i)
   `DV_FCOV_SIGNAL(logic, scr_write,
       (csr_op_o == CHERI_CSR_RW) && csr_op_en_o & cheri_operator_i[CCSR_RW] & cheri_exec_id_i)
- 
+
 endmodule
 
 ////////////////////////////////////////////////////////////////
@@ -349,7 +349,7 @@ endmodule
 module cheri_trvk_stage_dv_ext (
   input  logic                clk_i,
   input  logic                rst_ni,
- 
+
   input  logic                rf_trsv_en_i,
   input  logic [4:0]          rf_trsv_addr_i,
   input  logic [4:0]          rf_trvk_addr_o,
@@ -362,7 +362,7 @@ module cheri_trvk_stage_dv_ext (
   int         outstanding_trsv_cnt;
 
   // make sure all trsv reqs will be mapped to a trvk, in order.
-  initial begin 
+  initial begin
     int i;
 
     tqueue = {};
@@ -434,14 +434,14 @@ module cheri_tbre_dv_ext (
     logic [1:0] fifo_index;
 
     @(posedge rst_ni);
-   
+
     while (1) begin
       @(posedge clk_i);
       if (snoop_lsu_req_done_i) begin
         // search through req_fifo for hazard/collision case
         fcov_tbre_fifo_hazard      = 1'b0;
         fcov_tbre_fifo_head_hazard = 1'b0;
-        
+
         for (i = 0; i < req_fifo_depth; i++) begin
           fifo_index = cheri_tbre_i.fifo_rd_ptr + i;
           if (snoop_lsu_req_done_i & snoop_lsu_we_i & cheri_tbre_i.req_fifo_mem[fifo_index][21] &&
@@ -454,7 +454,7 @@ module cheri_tbre_dv_ext (
       end else begin
         fcov_tbre_fifo_hazard      = 1'b0;
         fcov_tbre_fifo_head_hazard = 1'b0;
-      end 
+      end
     end
   end
 
@@ -463,7 +463,7 @@ module cheri_tbre_dv_ext (
     fcov_tbre_done_addr  = 0;
     fcov_snoop_done_addr = 0;
     @(posedge rst_ni);
-   
+
     while (1) begin
       @(posedge clk_i);
       if (lsu_tbre_req_done_i) fcov_tbre_done_addr = tbre_lsu_addr_o;
@@ -493,12 +493,12 @@ module cheri_stkz_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
 
   always_comb begin
     if (ztop_wfcap_i.valid && (ztop_wfcap_i.base32 != ztop_wdata_i))
-      fcov_ztop_wr_type = 2'h0;           
+      fcov_ztop_wr_type = 2'h0;
     else if  (ztop_wfcap_i.valid)
       fcov_ztop_wr_type = 2'h1;
     else if ((ztop_wfcap_i == NULL_FULL_CAP) && (ztop_wdata_i == 0))
       fcov_ztop_wr_type = 2'h2;
-    else 
+    else
       fcov_ztop_wr_type = 2'h3;
   end
 
@@ -557,7 +557,7 @@ module ibex_core_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
 
     `ASSERT(NoMemRFWriteWithoutPendingLoad, rf_we_lsu |-> outstanding_load_resp, clk_i, !rst_ni)
   end
-  
+
   if (~u_ibex_core.CheriTBRE) begin
   `ASSERT(NoMemResponseWithoutPendingAccess,
     // this doesn't work for CLC since 1st data_rvalid comes back before wb
@@ -586,7 +586,7 @@ module ibex_core_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
       `ASSERT(CheriWrRegs, u_ibex_core.rf_we_wb |-> instr_done_wb, clk_i, !rst_ni)
     end
   end
- 
+
   // These assertions are in top-level as instr_valid_id required as the enable term
   `ASSERT(IbexCsrOpValid, u_ibex_core.instr_valid_id |-> u_ibex_core.csr_op inside {
       CSR_OP_READ,
@@ -675,19 +675,19 @@ module ibex_top_dv_ext import ibex_pkg::*; import cheri_pkg::*; (
 
   `ASSERT_KNOWN(IbexDataGntX, data_gnt_i)
   `ASSERT_KNOWN(IbexDataRValidX, data_rvalid_i)
-  
+
   // kliu - check data_rdata_i for reads only (FPGA ram model drives rdata for writes also)
   logic [3:0]  data_be_q;
   logic [32:0] data_strb;
 
-  assign data_strb = {|data_be_q, {8{data_be_q[3]}}, {8{data_be_q[2]}}, {8{data_be_q[1]}}, {8{data_be_q[0]}}} & 
+  assign data_strb = {|data_be_q, {8{data_be_q[3]}}, {8{data_be_q[2]}}, {8{data_be_q[1]}}, {8{data_be_q[0]}}} &
                      {33{~u_ibex_core.load_store_unit_i.data_we_q}};
   always @(posedge clk_i, negedge rst_ni) begin
     if (~rst_ni) data_be_q <= 4'h0;
     else if (data_req_o && data_gnt_i) data_be_q <= data_be_o;
   end
-  
-  `ASSERT_KNOWN_IF(IbexDataRPayloadX, {(data_strb & {33{~data_err_i}} &  data_rdata_i), 
+
+  `ASSERT_KNOWN_IF(IbexDataRPayloadX, {(data_strb & {33{~data_err_i}} &  data_rdata_i),
     ({7{~u_ibex_core.load_store_unit_i.data_we_q}} & data_rdata_intg_i), data_err_i}, data_rvalid_i)
 
   `ASSERT_KNOWN(IbexIrqX, {irq_software_i, irq_timer_i, irq_external_i, irq_fast_i, irq_nm_i})

--- a/dv/cheriot/tb/tb_cheriot_top.sv
+++ b/dv/cheriot/tb/tb_cheriot_top.sv
@@ -84,7 +84,7 @@ module tb_cheriot_top (
     defparam dut.u_ibex_top.WritebackStage = 1'b1;
     assign rf_rd_a_hz = dut.u_ibex_top.u_ibex_core.id_stage_i.gen_stall_mem.rf_rd_a_hz;
     assign rf_rd_b_hz = dut.u_ibex_top.u_ibex_core.id_stage_i.gen_stall_mem.rf_rd_b_hz;
-  `endif  
+  `endif
 
   `ifdef MEMCAPFMT1
     defparam dut.u_ibex_top.MemCapFmt = 1'b1;
@@ -118,16 +118,16 @@ module tb_cheriot_top (
     assign cheri_pmode = 1'b1;
   `endif
 
-  `ifdef TSAFE0 
+  `ifdef TSAFE0
     assign cheri_tsafe_en = 0;
   `else
     assign cheri_tsafe_en = 1;
   `endif
 
-  `ifdef MULT_1CYCLE  
+  `ifdef MULT_1CYCLE
     defparam dut.u_ibex_top.u_ibex_core.RV32M = RV32MSingleCycle;
   `endif
-   
+
   `ifdef BRANCH_PREDICT
     defparam dut.u_ibex_top.BranchPredictor = 1'b1;
   `endif
@@ -184,7 +184,7 @@ module tb_cheriot_top (
     .irq_timer_i          (irq_timer   ),
     .irq_external_i       (irq_external),
     .irq_fast_i           (15'h0       ),
-    .irq_nm_i             (1'b0        ), 
+    .irq_nm_i             (1'b0        ),
     .scramble_key_valid_i (1'b0        ),
     .scramble_key_i       (128'h0      ),
     .scramble_nonce_i     (64'h0       ),
@@ -196,18 +196,18 @@ module tb_cheriot_top (
     .data_is_cap_o        ()
   );
 
-  assign {irq_timer, irq_software,  irq_external} = irq_vec; 
+  assign {irq_timer, irq_software,  irq_external} = irq_vec;
 
   assign data_rdata_intg  = 7'h0;
   assign instr_rdata_intg = 7'h0;
-  
+
   // detect internal alerts
   always @(posedge clk_i) begin
 
     if (dut.u_ibex_top.alert_major_internal_o | dut.u_ibex_top.alert_major_bus_o |
         dut.u_ibex_top.alert_minor_o) begin
       $display("Alert detected !!!!!!! @%t, major_int = %1b, major_bus = %1b, minor = %1b", $time,
-               dut.u_ibex_top.alert_major_internal_o, dut.u_ibex_top.alert_major_bus_o, 
+               dut.u_ibex_top.alert_major_internal_o, dut.u_ibex_top.alert_major_bus_o,
                dut.u_ibex_top.alert_minor_o);
     end
   end
@@ -216,7 +216,7 @@ module tb_cheriot_top (
 `ifndef VERILATOR
   initial begin
     #0 $fsdbDumpfile("tb_cheriot_top.fsdb");
-    $fsdbDumpvars(0, "+all", tb_cheriot_top); 
+    $fsdbDumpvars(0, "+all", tb_cheriot_top);
   end
 `endif
 
@@ -232,11 +232,11 @@ module tb_cheriot_top (
   );
 
 
-`ifdef DII_SIM 
+`ifdef DII_SIM
   assign instr_rdata = 32'h0;
 `else
   assign instr_rdata = instr_rdata_mem;
-`endif  
+`endif
 
   logic [2:0] instr_err_rate, data_err_rate;
   logic [3:0] instr_gnt_wmax, data_gnt_wmax;
@@ -292,17 +292,17 @@ module tb_cheriot_top (
     repeat (10) @(posedge clk_i);    // wait after the hardware mtvec init
   end
 
-  
+
   assign instr_err_enable = err_enable_vec[0];
   assign data_err_enable  = err_enable_vec[1];
   assign intr_enable      = err_enable_vec[2];
   assign cap_err_enable   = err_enable_vec[3];
 
   //
-  // RAMs 
+  // RAMs
   //
   instr_mem_model u_instr_mem (
-    .clk             (clk_i         ), 
+    .clk             (clk_i         ),
     .rst_n           (rstn_i        ),
     .ERR_RATE        (instr_err_rate),
     .GNT_WMAX        (instr_gnt_wmax),
@@ -317,7 +317,7 @@ module tb_cheriot_top (
   );
 
   data_mem_model u_data_mem (
-    .clk             (clk_i        ), 
+    .clk             (clk_i        ),
     .rst_n           (rstn_i       ),
     .ERR_RATE        (data_err_rate),
     .GNT_WMAX        (data_gnt_wmax),
@@ -338,25 +338,25 @@ module tb_cheriot_top (
     .mmreg_corein    (mmreg_corein),
     .mmreg_coreout   (mmreg_coreout),
     .err_enable_vec  (err_enable_vec),
-    .intr_ack        (intr_ack     )  
+    .intr_ack        (intr_ack     )
   );
 
   //
   // random interrupt generator
   //
   intr_gen u_intr_gen (
-    .clk             (clk_i        ), 
+    .clk             (clk_i        ),
     .rst_n           (rstn_i       ),
     .INTR_INTVL      (intr_intvl   ),
     .intr_en         (intr_enable  ),
-    .intr_ack        (intr_ack     ),  
+    .intr_ack        (intr_ack     ),
     .irq_o           (irq_vec      )
   );
 
   //
   // random cap error injection
   //
-  cap_err_gen u_cap_err_gen ( 
+  cap_err_gen u_cap_err_gen (
     .clk             (clk_i        ),
     .rst_n           (rstn_i       ),
     .ERR_RATE        (cap_err_rate ),
@@ -366,4 +366,3 @@ module tb_cheriot_top (
 
 
 endmodule
-

--- a/dv/cheriot/tb/tb_env.sv
+++ b/dv/cheriot/tb/tb_env.sv
@@ -29,14 +29,14 @@ module tb_env;
     end
   end
 
- 
+
 `ifdef DII_SIM
 
   always @(negedge clk, negedge rst_n) begin
     if (~rst_n) begin
       dii_insn <= 32'h1;
     end else begin
-      dii_insn <= nxt_instr;      // select between possible nxt_instr streams 
+      dii_insn <= nxt_instr;      // select between possible nxt_instr streams
     end
   end
 
@@ -53,8 +53,8 @@ module tb_env;
     rst_n = 1'b1;
     #1;
     rst_n = 1'b0;
-   
-    $readmemh("./bin/instr_stream.vhx", instr_stream, 'h0);   // load stream 
+
+    $readmemh("./bin/instr_stream.vhx", instr_stream, 'h0);   // load stream
     nxt_instr = instr_stream[0];
 
     repeat(10) @(posedge clk);
@@ -74,7 +74,7 @@ module tb_env;
     end
 
     repeat(10) @(posedge clk); // let the last instruction propagate through
-    
+
     $finish;
   end
 
@@ -99,18 +99,18 @@ module tb_env;
     rst_n = 1'b0;
 
     // overlaying the same image in both instr_mem model and data_mem model
-    // so that we can get RO data. this works in this setup since we only use static code images. 
+    // so that we can get RO data. this works in this setup since we only use static code images.
     $readmemh(vhx_path, u_tb_top.u_instr_mem.iram, 'h0);   // load main executable
     $readmemh(vhx_path, u_tb_top.u_data_mem.dram, 'h0);   // load main executable
 
     //for (i=0; i<64;i++)
     //  $display("%08x %08x %08x %08x", u_tb_top.u_instr_mem.mem[4*i], u_tb_top.u_instr_mem.mem[4*i+1],
     //                                  u_tb_top.u_instr_mem.mem[4*i+2], u_tb_top.u_instr_mem.mem[4*i+3]);
-   
-    
+
+
     repeat(10) @(posedge clk);
     rst_n = 1'b1;
-    
+
     cont_flag = 1;
     while (cont_flag) begin
       @(posedge clk);

--- a/dv/cs_registers/README.md
+++ b/dv/cs_registers/README.md
@@ -48,4 +48,3 @@ Testbench structure
 The driver component contains one DPI "interface" to drive new random transactions into the DUT, and another to monitor issued transactions including the DUT's responses.
 Each time a new transaction is detected by the monitor component, it is captured and sent to the model.
 The model reads incoming transactions, updates its internal state and checks that the DUT outputs matches its own predictions.
-

--- a/dv/cs_registers/env/env_dpi.sv
+++ b/dv/cs_registers/env/env_dpi.sv
@@ -21,5 +21,3 @@ package env_dpi;
     output bit test_passed);
 
 endpackage
-
-

--- a/dv/cs_registers/reg_driver/reg_dpi.sv
+++ b/dv/cs_registers/reg_driver/reg_dpi.sv
@@ -26,4 +26,3 @@ package reg_dpi;
     output bit [31:0] csr_wdata);
 
 endpackage
-

--- a/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
+++ b/dv/uvm/core_ibex/common/irq_agent/irq_request_driver.sv
@@ -78,4 +78,3 @@ class irq_request_driver extends uvm_driver #(irq_seq_item);
   endtask : drive_reset_value
 
 endclass : irq_request_driver
-

--- a/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
+++ b/dv/uvm/icache/dv/env/ibex_icache_scoreboard.sv
@@ -424,7 +424,7 @@ class ibex_icache_scoreboard
     bit [BusWidth-1:0] rdata;
 
     bit [31:0]         seed;
-    int unsigned       mem_err_shift;      
+    int unsigned       mem_err_shift;
 
     bus_shift = $clog2(BusWidth / 8);
     addr_lo = (address >> bus_shift) << bus_shift;

--- a/dv/uvm/icache/dv/tests/ibex_icache_oldval_test.sv
+++ b/dv/uvm/icache/dv/tests/ibex_icache_oldval_test.sv
@@ -41,4 +41,3 @@ class ibex_icache_oldval_test extends ibex_icache_base_test;
   endfunction : check_phase
 
 endclass : ibex_icache_oldval_test
-

--- a/dv/verilator/pcount/ibex_pcounts.core
+++ b/dv/verilator/pcount/ibex_pcounts.core
@@ -16,4 +16,3 @@ targets:
   default:
     filesets:
       - files_cpp
-

--- a/dv/verilator/simple_system_cosim/README.md
+++ b/dv/verilator/simple_system_cosim/README.md
@@ -20,7 +20,7 @@ mkdir build
 cd build
 
 # Configure and build spike
-../configure --enable-commitlog --enable-misaligned --prefix=/opt/spike-cosim 
+../configure --enable-commitlog --enable-misaligned --prefix=/opt/spike-cosim
 # Installs in /opt/spike-cosim
 sudo make -j8 install
 
@@ -36,7 +36,7 @@ cd <ibex_repo>
 # Build simulator
 fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_simple_system_cosim --RV32E=0 --RV32M=ibex_pkg::RV32MFast
 
-# Build coremark test binary, with performance counter dump disabled. The 
+# Build coremark test binary, with performance counter dump disabled. The
 # co-simulator system doesn't produce matching performance counters in spike so
 # any read of those CSRs results in a mismatch and a failure.
 make -C ./examples/sw/benchmarks/coremark SUPPRESS_PCOUNT_DUMP=1

--- a/examples/fpga/artya7/top_artya7.core
+++ b/examples/fpga/artya7/top_artya7.core
@@ -41,7 +41,7 @@ parameters:
     datatype: str
     paramtype: vlogdefine
     description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
- 
+
   FPGAPowerAnalysis:
     datatype: int
     paramtype: vlogparam

--- a/rtl/cheri_decoder.sv
+++ b/rtl/cheri_decoder.sv
@@ -111,8 +111,8 @@ module cheri_decoder import cheri_pkg::*; # (
   // register dependency decoding
   // only handled opcode=0x5b case here.
   // Will be qualified and combined with other cases by ibexc_decoder
-  //   - note: rf_reb_b_o actually should be '0' for CSPECIALRW. 
-  //     however that's the only mismatch case so performance loss due to stalling 
+  //   - note: rf_reb_b_o actually should be '0' for CSPECIALRW.
+  //     however that's the only mismatch case so performance loss due to stalling
   //     should be small, and so we choose to have simpler decoder for timing
   assign cheri_rf_ren_a_o = 1'b1;
   assign cheri_rf_ren_b_o = (func3_op == 0) && (func7_op != 7'h7f);

--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -130,7 +130,7 @@ module cheri_ex import cheri_pkg::*; #(
   input  logic [31:0]   csr_mshwmb_i,
   output logic          csr_mshwm_set_o,
   output logic [31:0]   csr_mshwm_new_o,
-  
+
   // stack fast clearing control signals
   input  logic          stkz_active_i,
   input  logic          stkz_abort_i,
@@ -201,7 +201,7 @@ module cheri_ex import cheri_pkg::*; #(
   logic          cheri_ex_valid_raw, cheri_ex_err_raw;
   logic          csr_op_en_raw;
   logic          cheri_wb_err_raw;
-  logic          cheri_wb_err_q, cheri_wb_err_d; 
+  logic          cheri_wb_err_q, cheri_wb_err_d;
   logic          ztop_wr_raw;
 
   logic   [3:0]  cheri_lsu_lc_clrperm;
@@ -254,7 +254,7 @@ module cheri_ex import cheri_pkg::*; #(
   assign rf_fullcap_a = reg2fullcap(rf_rcap_a, rf_rdata_a);
   assign rf_fullcap_b = reg2fullcap(rf_rcap_b, rf_rdata_b);
 
-  // gate these signals with cheri_exec_id to make sure they are only active when needed 
+  // gate these signals with cheri_exec_id to make sure they are only active when needed
   // (only 1 cycle in all cases other than cheri_rf_we)
   // -- safest approach and probably the right thing to do in case there is a wb_exception
   assign cheri_rf_we_o     = cheri_rf_we_raw & cheri_exec_id_i;
@@ -513,10 +513,10 @@ module cheri_ex import cheri_pkg::*; #(
         begin
           logic [31:0] tmp32;
           logic        is_ztop, is_write;
-          
+
           is_ztop            = (cheri_cs2_dec_i==CHERI_SCR_ZTOPC);
           is_write           = (rf_raddr_a_i != 0);
-                            
+
           csr_access_o       = ~perm_vio;
           csr_op_o           = CHERI_CSR_RW;
           csr_op_en_raw      = ~perm_vio && is_write && ~is_ztop;
@@ -524,13 +524,13 @@ module cheri_ex import cheri_pkg::*; #(
           csr_addr_o         = cheri_cs2_dec_i;
 
           if ((cheri_cs2_dec_i==CHERI_SCR_MTCC)||(cheri_cs2_dec_i==CHERI_SCR_MEPCC)) begin
-            // MTVEC/MTCC or MEPCC 
-            csr_wdata_o      = rf_rdata_a;          
+            // MTVEC/MTCC or MEPCC
+            csr_wdata_o      = rf_rdata_a;
             csr_wcap_o       = full2regcap(setaddr1_outcap);
           end else begin
-            csr_wdata_o      = rf_rdata_a;          
+            csr_wdata_o      = rf_rdata_a;
             csr_wcap_o       = rf_rcap_a;
-          end 
+          end
 
           if (is_ztop) begin
             result_data_o    = ztop_rdata_i;
@@ -541,11 +541,11 @@ module cheri_ex import cheri_pkg::*; #(
             result_data_o    = csr_rdata_i;
             result_cap_o     = csr_rcap_i;
             ztop_wfcap_o     = NULL_FULL_CAP;
-            ztop_wdata_o     = 32'h0; 
+            ztop_wdata_o     = 32'h0;
           end
           cheri_rf_we_raw    = ~perm_vio;
           cheri_ex_valid_raw = 1'b1;
-          cheri_wb_err_raw   = perm_vio; 
+          cheri_wb_err_raw   = perm_vio;
         end
       (cheri_operator_i[CJALR] | cheri_operator_i[CJAL]):
         begin                  // cd <-- pcc; pcc <-- cs1/pc+offset; pcc.address[0] <--'0'; pcc.sealed <--'0'
@@ -575,9 +575,9 @@ module cheri_ex import cheri_pkg::*; #(
 
           cheri_wb_err_raw     = instr_fault;
           cheri_ex_err_raw     = 1'b0;
-          csr_set_mie_raw      = ~instr_fault && cheri_operator_i[CJALR] && 
+          csr_set_mie_raw      = ~instr_fault && cheri_operator_i[CJALR] &&
                                  (rf_fullcap_a.otype == OTYPE_SENTRY_IE);
-          csr_clr_mie_raw      = ~instr_fault && cheri_operator_i[CJALR] && 
+          csr_clr_mie_raw      = ~instr_fault && cheri_operator_i[CJALR] &&
                                  (rf_fullcap_a.otype == OTYPE_SENTRY_ID);
           cheri_ex_valid_raw   = 1'b1;
         end
@@ -596,13 +596,13 @@ module cheri_ex import cheri_pkg::*; #(
 
   if (WritebackStage) begin
     // assert LSU req until instruction is retired (req_done from LSU)
-    // note if the previous instr is also a load/store, cheri_exec_id won't be asserted 
+    // note if the previous instr is also a load/store, cheri_exec_id won't be asserted
     // till WB is ready (lsu_resp for the previous isntr)
     assign cheri_lsu_req      = is_intl ? intl_lsu_req : is_cap & cheri_exec_id_i;
   end else begin
     // no WB stage, only assert req in the first_cycle phase of the instruction
     // (consistent with the RV32 load/store instructions)
-    // Here instruction won't complete till lsu_resp_valid in this case, 
+    // Here instruction won't complete till lsu_resp_valid in this case,
     // keeping lsu_req asserted causes problem as LSU sees it as a new request
     assign cheri_lsu_req      = is_intl ? intl_lsu_req : is_cap & cheri_exec_id_i & instr_first_cycle_i;
   end
@@ -739,7 +739,7 @@ module cheri_ex import cheri_pkg::*; #(
         // since the multicycle control logic won't look at ex_valid till the 2nd cycle
         // however this is the cleaner solution.
         set_bounds_done <= (cheri_operator_i[CSET_BOUNDS] | cheri_operator_i[CSET_BOUNDS_IMM] |
-                            cheri_operator_i[CSET_BOUNDS_EX] | cheri_operator_i[CRRL] | 
+                            cheri_operator_i[CSET_BOUNDS_EX] | cheri_operator_i[CRRL] |
                             cheri_operator_i[CRAM]) & cheri_exec_id_i & ~set_bounds_done ;
       end
     end
@@ -809,7 +809,7 @@ module cheri_ex import cheri_pkg::*; #(
     perm_vio_vec_rv32[PVIO_SEAL] = is_cap_sealed(rf_fullcap_a);
     perm_vio_vec_rv32[PVIO_LD]   = ((~rv32_lsu_we_i) && (~rf_fullcap_a.perms[PERM_LD]));
     perm_vio_vec_rv32[PVIO_SD]   = (rv32_lsu_we_i && (~rf_fullcap_a.perms[PERM_SD]));
-    
+
     perm_vio_rv32 =  |perm_vio_vec_rv32;
   end
 
@@ -847,7 +847,7 @@ module cheri_ex import cheri_pkg::*; #(
       top_chkaddr = {base_chkaddr[31:1], 1'b0};
     else if (is_cap)  // CLC/CSC
       top_chkaddr = {base_chkaddr[31:3], 3'b000};
-    else 
+    else
       top_chkaddr = base_chkaddr;
 
     if (cheri_operator_i[CSEAL] | cheri_operator_i[CUNSEAL]) begin
@@ -873,9 +873,9 @@ module cheri_ex import cheri_pkg::*; #(
 
     if (debug_mode_i)
       addr_bound_vio = 1'b0;
-    else if (is_cap) 
+    else if (is_cap)
       addr_bound_vio = top_vio | base_vio | top_equal;
-    else if (cheri_operator_i[CIS_SUBSET]) 
+    else if (cheri_operator_i[CIS_SUBSET])
       addr_bound_vio = top_vio | base_vio;
     else if (cheri_operator_i[CJAL] | cheri_operator_i[CJALR])
       addr_bound_vio = top_vio | base_vio | top_equal;
@@ -888,7 +888,7 @@ module cheri_ex import cheri_pkg::*; #(
     perm_vio_vec = 0;
     cs2_bad_type = 1'b0;
 
-    // note cseal/unseal/cis_subject doesn't generate exceptions, 
+    // note cseal/unseal/cis_subject doesn't generate exceptions,
     // so for all exceptions, violations can always be attributed to cs1, thus no need to further split
     // exceptions based on source operands.
     if (is_load_cap) begin
@@ -897,32 +897,32 @@ module cheri_ex import cheri_pkg::*; #(
       perm_vio_vec[PVIO_LD]    = ~(rf_fullcap_a.perms[PERM_LD]);
       perm_vio_vec[PVIO_ALIGN] = (cheri_ls_chkaddr[2:0] != 0);
     end else if (is_store_cap) begin
-      perm_vio_vec[PVIO_TAG]   = (~rf_fullcap_a.valid); 
+      perm_vio_vec[PVIO_TAG]   = (~rf_fullcap_a.valid);
       perm_vio_vec[PVIO_SEAL]  = is_cap_sealed(rf_fullcap_a);
       perm_vio_vec[PVIO_SD]    = ~rf_fullcap_a.perms[PERM_SD];
       perm_vio_vec[PVIO_SC]    = (~rf_fullcap_a.perms[PERM_MC] && rf_fullcap_b.valid);
-      perm_vio_vec[PVIO_ALIGN] = (cheri_ls_chkaddr[2:0] != 0); 
+      perm_vio_vec[PVIO_ALIGN] = (cheri_ls_chkaddr[2:0] != 0);
       perm_vio_vec[PVIO_SLC]   = ~rf_fullcap_a.perms[PERM_SL] && rf_fullcap_b.valid && ~rf_fullcap_b.perms[PERM_GL];
     end else if (cheri_operator_i[CSEAL]) begin
-      cs2_bad_type = rf_fullcap_a.perms[PERM_EX] ? 
-                     ((rf_rdata_b[31:3]!=0)||(rf_rdata_b[2:0]==0)||(rf_rdata_b[2:0]==3'h4)||(rf_rdata_b[2:0]==3'h5)) : 
+      cs2_bad_type = rf_fullcap_a.perms[PERM_EX] ?
+                     ((rf_rdata_b[31:3]!=0)||(rf_rdata_b[2:0]==0)||(rf_rdata_b[2:0]==3'h4)||(rf_rdata_b[2:0]==3'h5)) :
                      ((|rf_rdata_b[31:4]) || (rf_rdata_b[3:0] <= 8));
       // cs2.addr check : ex: 0-7, non-ex: 9-15
       perm_vio_vec[PVIO_TAG]   = ~rf_fullcap_a.valid || ~rf_fullcap_b.valid;
-      perm_vio_vec[PVIO_SEAL]  = is_cap_sealed(rf_fullcap_a) || is_cap_sealed(rf_fullcap_b) || 
+      perm_vio_vec[PVIO_SEAL]  = is_cap_sealed(rf_fullcap_a) || is_cap_sealed(rf_fullcap_b) ||
                                   (~rf_fullcap_b.perms[PERM_SE]) || cs2_bad_type;
     end else if (cheri_operator_i[CUNSEAL]) begin
-      perm_vio_vec[PVIO_TAG]   = ~rf_fullcap_a.valid || ~rf_fullcap_b.valid; 
+      perm_vio_vec[PVIO_TAG]   = ~rf_fullcap_a.valid || ~rf_fullcap_b.valid;
       perm_vio_vec[PVIO_SEAL]  = (~is_cap_sealed(rf_fullcap_a)) || is_cap_sealed(rf_fullcap_b) ||
                                    (rf_rdata_b != decode_otype(rf_fullcap_a.otype, rf_fullcap_a.perms[PERM_EX])) ||
                                    (~rf_fullcap_b.perms[PERM_US]);
     end else if (cheri_operator_i[CJALR]) begin
       perm_vio_vec[PVIO_TAG]   = (~rf_fullcap_a.valid);
-      perm_vio_vec[PVIO_SEAL]  = (is_cap_sealed(rf_fullcap_a) && (~is_cap_sentry(rf_fullcap_a))); 
-      perm_vio_vec[PVIO_EX]    = ~rf_fullcap_a.perms[PERM_EX]; 
+      perm_vio_vec[PVIO_SEAL]  = (is_cap_sealed(rf_fullcap_a) && (~is_cap_sentry(rf_fullcap_a)));
+      perm_vio_vec[PVIO_EX]    = ~rf_fullcap_a.perms[PERM_EX];
       perm_vio_vec[PVIO_ALIGN] = (is_cap_sentry(rf_fullcap_a) && (cheri_imm12_i != 0)) || (addr_result[0]);
     end else if (cheri_operator_i[CJAL]) begin
-      perm_vio_vec[PVIO_ALIGN] = addr_result[0]; 
+      perm_vio_vec[PVIO_ALIGN] = addr_result[0];
     end else if (cheri_operator_i[CCSR_RW]) begin
       perm_vio_vec[PVIO_ASR]   =  ~pcc_cap_i.perms[PERM_SR] || (csr_addr_o < 27);
     end else begin
@@ -934,7 +934,7 @@ module cheri_ex import cheri_pkg::*; #(
 
   // qualified by lsu_req later
   // store_local error only causes tag clearing unless escalated to fault for debugging
-  assign cheri_lsu_err = cheri_pmode_i & ~debug_mode_i & 
+  assign cheri_lsu_err = cheri_pmode_i & ~debug_mode_i &
                          (addr_bound_vio | (|perm_vio_vec[7:0]) | (csr_dbg_tclr_fault_i & perm_vio_vec[PVIO_SLC]));
 
   //
@@ -947,8 +947,8 @@ module cheri_ex import cheri_pkg::*; #(
 
   assign cheri_wb_err_d      = cheri_wb_err_raw & cheri_exec_id_i & ~debug_mode_i;
 
-  // addr_bound_vio is the timing optimized version (gating data_req) 
-  // However we need to generate full version of addr_bound_vio to match the sail exception 
+  // addr_bound_vio is the timing optimized version (gating data_req)
+  // However we need to generate full version of addr_bound_vio to match the sail exception
   // priority definition (bound_vio has higher priority over alignment_error).
   // this has less timing impact since it goes to a flop stage
   logic addr_bound_vio_ext;
@@ -958,19 +958,19 @@ module cheri_ex import cheri_pkg::*; #(
   assign addr_bound_vio_ext = is_cap ?  addr_bound_vio | (cheri_top_chkaddr_ext > rf_fullcap_a.top33) :
                               addr_bound_vio;
 
-  always_comb begin : err_cause_comb 
+  always_comb begin : err_cause_comb
     cheri_err_cause  = vio_cause_enc(addr_bound_vio_ext, perm_vio_vec);
     rv32_err_cause   = vio_cause_enc(addr_bound_vio_rv32, perm_vio_vec_rv32);
 
     ls_addr_misaligned_only = perm_vio_vec[PVIO_ALIGN] && (cheri_err_cause == 0);
-    
-    if (cheri_exec_id_i & ~CheriPPLBC & cheri_tsafe_en_i & is_load_cap & cheri_lsu_err)  
+
+    if (cheri_exec_id_i & ~CheriPPLBC & cheri_tsafe_en_i & is_load_cap & cheri_lsu_err)
       // 2-stage ppl load/store, error treated as EX error, cheri CLC check error
       cheri_ex_err_info_d = {2'b00, rf_raddr_a_i, cheri_err_cause};
-    else if (cheri_exec_id_i & ~CheriPPLBC & cheri_tsafe_en_i & is_load_cap & clbc_err)  
+    else if (cheri_exec_id_i & ~CheriPPLBC & cheri_tsafe_en_i & is_load_cap & clbc_err)
       // 2-stage ppl load/store, error treated as EX error, memory error
-      cheri_ex_err_info_d = {2'b00, rf_raddr_a_i, 5'h1f};    
-    else 
+      cheri_ex_err_info_d = {2'b00, rf_raddr_a_i, 5'h1f};
+    else
       cheri_ex_err_info_d = cheri_ex_err_info_q;
 
     // cheri_wb_err_raw is already qualified by instr
@@ -983,9 +983,9 @@ module cheri_ex import cheri_pkg::*; #(
       cheri_wb_err_info_d = {ls_addr_misaligned_only, 1'b0, rf_raddr_a_i, cheri_err_cause};
     else if (rv32_lsu_req_i & rv32_lsu_err)
       cheri_wb_err_info_d = {1'b0, 1'b0, rf_raddr_a_i, rv32_err_cause};
-    else 
+    else
       cheri_wb_err_info_d = cheri_wb_err_info_q;
-  end 
+  end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -993,9 +993,9 @@ module cheri_ex import cheri_pkg::*; #(
       cheri_wb_err_info_q <= 'h0;
       cheri_ex_err_info_q <= 'h0;
     end else begin
-      // Simple flop here works since if cheri_wb_err, lsu request won't be generated 
-      //   so wb stage only takes 1 cycle. 
-      cheri_wb_err_q      <= cheri_wb_err_d; 
+      // Simple flop here works since if cheri_wb_err, lsu request won't be generated
+      //   so wb stage only takes 1 cycle.
+      cheri_wb_err_q      <= cheri_wb_err_d;
       cheri_wb_err_info_q <= cheri_wb_err_info_d;
       cheri_ex_err_info_q <= cheri_ex_err_info_d;
     end
@@ -1112,14 +1112,14 @@ logic cpu_stkz_err;
 if (CheriStkZ) begin
   // load/store takes 1 cycle when stkz_active
   assign lsu_req_o         = ~cpu_stkz_stall0 & (instr_is_cheri_i ? cheri_lsu_req : rv32_lsu_req_i);
-  assign cpu_lsu_dec_o     = ~cpu_stkz_stall1 & ((instr_is_cheri_i && is_cap) | instr_is_rv32lsu_i);  
+  assign cpu_lsu_dec_o     = ~cpu_stkz_stall1 & ((instr_is_cheri_i && is_cap) | instr_is_rv32lsu_i);
 end else begin
   assign lsu_req_o         = (instr_is_cheri_i ? cheri_lsu_req : rv32_lsu_req_i);
-  assign cpu_lsu_dec_o     = ((instr_is_cheri_i && is_cap) | instr_is_rv32lsu_i);  
+  assign cpu_lsu_dec_o     = ((instr_is_cheri_i && is_cap) | instr_is_rv32lsu_i);
 
 end
 
-  assign cpu_lsu_cheri_err = cpu_stkz_err | (instr_is_cheri_i ? cheri_lsu_err : rv32_lsu_err); 
+  assign cpu_lsu_cheri_err = cpu_stkz_err | (instr_is_cheri_i ? cheri_lsu_err : rv32_lsu_err);
   assign cpu_lsu_addr      = instr_is_cheri_i ? cheri_lsu_addr : rv32_lsu_addr_i;
   assign cpu_lsu_we        = instr_is_cheri_i ? cheri_lsu_we : rv32_lsu_we_i;
   assign cpu_lsu_wdata     = instr_is_cheri_i ? cheri_lsu_wdata : {1'b0, rv32_lsu_wdata_i};
@@ -1157,16 +1157,16 @@ end
   //
   // Stack high watermark CSR update
   //
-  
+
   // Notes,
   //  - this should also take care of unaligned access (which increases addr only)
   //    (although stack access should not have any)
-  //  - it's also ok if the prev instr gets faulted in WB, since stall_mem/data_req_allowed logic  ensures 
+  //  - it's also ok if the prev instr gets faulted in WB, since stall_mem/data_req_allowed logic  ensures
   //    that lsu_req won't be issued till memory response/error comes back
-  //  - what if the instruction gets faulted later in WB stage? Also fine since worst case even if HM is 
+  //  - what if the instruction gets faulted later in WB stage? Also fine since worst case even if HM is
   //    too aggressive we will just have to spend more time zeroing out more stack area.
-  
-  assign csr_mshwm_set_o = lsu_req_o & ~lsu_cheri_err_o & lsu_we_o & 
+
+  assign csr_mshwm_set_o = lsu_req_o & ~lsu_cheri_err_o & lsu_we_o &
                            (lsu_addr_o[31:4] >= csr_mshwmb_i[31:4]) & (lsu_addr_o[31:4] < csr_mshwm_i[31:4]);
   assign csr_mshwm_new_o = {lsu_addr_o[31:4], 4'h0};
 
@@ -1178,19 +1178,19 @@ end
   if (CheriStkZ) begin
     logic lsu_addr_in_range, stkz_stall_q;
 
-    assign lsu_addr_in_range = (cpu_lsu_addr[31:4] >= stkz_base_i[31:4]) && 
+    assign lsu_addr_in_range = (cpu_lsu_addr[31:4] >= stkz_base_i[31:4]) &&
                                (cpu_lsu_addr[31:2] < stkz_ptr_i[31:2]);
 
-    // cpu_lsu_dec_o is meant to be an early hint to help LSU to generate mux selects for 
+    // cpu_lsu_dec_o is meant to be an early hint to help LSU to generate mux selects for
     // address/ctrl/wdata (eventually to help timing on those output ports)
     // - we always suppress lsu_req if stkclr active and address-in-range (to be cleared)
-    // - however in the first cycle we speculatively still assert cpu_lsu_dec_o to let LSU choose 
+    // - however in the first cycle we speculatively still assert cpu_lsu_dec_o to let LSU choose
     //   the address from cpu core (and hold back stkz/tbre_req). In the next cycle we can deassert
     //   cpu_lsu_dec_o to let stkz/tbre_req go through
-    //   -- Note stkz_active_i is asserted synchronously by writing to the new stkz_ptr CSR. 
-    //      As such it is not possible for active to go from '0' to '1' in the middle of an 
+    //   -- Note stkz_active_i is asserted synchronously by writing to the new stkz_ptr CSR.
+    //      As such it is not possible for active to go from '0' to '1' in the middle of an
     //      load/store instruction when we want to keep lsu_req high while waiting for lsu_req_done
-    assign cpu_stkz_stall0 = (instr_first_cycle_i & stkz_active_i & lsu_addr_in_range) | stkz_stall_q; 
+    assign cpu_stkz_stall0 = (instr_first_cycle_i & stkz_active_i & lsu_addr_in_range) | stkz_stall_q;
     assign cpu_stkz_stall1 = ~instr_first_cycle_i & stkz_stall_q;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/rtl/cheri_pkg.sv
+++ b/rtl/cheri_pkg.sv
@@ -299,9 +299,9 @@ package cheri_pkg;
   endfunction
 
   // set address of a capability
-  //   by default we check for representability only. 
+  //   by default we check for representability only.
   //   use checktop/checkbase to check explicitly against top33/base32 bounds (pcc updates)
-  //   * note, representability check in most cases (other than exp=24) covers the base32 check 
+  //   * note, representability check in most cases (other than exp=24) covers the base32 check
 
   function automatic full_cap_t set_address (full_cap_t in_cap, logic [31:0] newptr, logic chktop, logic chkbase);
     full_cap_t        out_cap;
@@ -450,7 +450,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     // also compare address >= old base 32 to handle exp=24 case
     //   exp = 24 case: can have addr < base (not covered by representibility checking);
     //   other exp cases: always addr >= base when out_cap.tag == 1
-    if ((top33req > in_cap.top33) || (addr < in_cap.base32)) 
+    if ((top33req > in_cap.top33) || (addr < in_cap.base32))
       out_cap.valid = 1'b0;
 
     return out_cap;
@@ -512,7 +512,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
     full_cap.top33  = get_bound33(reg_cap.top, reg_cap.top_cor, reg_cap.exp, addr);
     full_cap.base32 = get_bound33(reg_cap.base, reg_cap.base_cor, reg_cap.exp, addr);
-    // full_cap  = update_bounds(full_cap, addr);   // for some reason this increases area 
+    // full_cap  = update_bounds(full_cap, addr);   // for some reason this increases area
 
     full_cap.maska    = 0;
     full_cap.rlen     = 0;
@@ -547,8 +547,8 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
   function automatic full_cap_t pcc2fullcap (pcc_cap_t in_pcap);
     full_cap_t pcc_fullcap;
 
-    pcc_fullcap.valid    = in_pcap.valid;   
-    pcc_fullcap.exp      = in_pcap.exp; 
+    pcc_fullcap.valid    = in_pcap.valid;
+    pcc_fullcap.exp      = in_pcap.exp;
     pcc_fullcap.top33    = in_pcap.top33;
     pcc_fullcap.base32   = in_pcap.base32;
     pcc_fullcap.otype    = in_pcap.otype;
@@ -561,7 +561,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     pcc_fullcap.maska    = 0;             // not used in pcc_cap
     pcc_fullcap.rsvd     = in_pcap.rsvd;
     pcc_fullcap.rlen     = 0;             // not used in pcc_cap
- 
+
     return pcc_fullcap;
   endfunction
 
@@ -614,7 +614,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     logic                valid_in;
 
     valid_in      = msw[32] & addr33[32];
-    regcap.valid  = valid_in & ~clrperm[3];   
+    regcap.valid  = valid_in & ~clrperm[3];
 
     tmp32    = msw[CEXP_LO+:CEXP_W];
     if (tmp32 == RESETCEXP) tmp32 = RESETEXP;
@@ -627,7 +627,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     sealed = (regcap.otype != OTYPE_UNSEALED);
     cperms_mem      = msw[CPERMS_LO+:CPERMS_W];
     regcap.cperms   = mask_clcperms(cperms_mem, clrperm, valid_in, sealed);
-    addrmi9         = {1'b0, addr33[31:0]} >> regcap.exp;   // ignore the tag valid bit 
+    addrmi9         = {1'b0, addr33[31:0]} >> regcap.exp;   // ignore the tag valid bit
     tmp4            = update_temp_fields(regcap.top, regcap.base, addrmi9);
     regcap.top_cor  = tmp4[3:2];
     regcap.base_cor = tmp4[1:0];
@@ -670,7 +670,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
     // lsw is now EXP+B+T+A
     valid_in      = msw[32] & lsw[32];
-    regcap.valid  = valid_in & ~clrperm[3];   
+    regcap.valid  = valid_in & ~clrperm[3];
     regcap.exp    = (lsw[30:27] == RESETCEXP) ?  RESETEXP : {1'b0, lsw[30:27]};
     regcap.base   = lsw[26:18];
     regcap.top    = lsw[17:9];
@@ -744,7 +744,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
   endfunction
 
-  // simply cast regcap to a 38-bit vector. 
+  // simply cast regcap to a 38-bit vector.
   // we can do this with systemverilog casting but let's be explicit here
   function automatic logic [REGCAP_W-1:0] reg2vec (reg_cap_t regcap);
 
@@ -767,27 +767,27 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
     reg_cap_t regcap;
 
-    regcap.valid    = vec_in[REGCAP_W-1];  
-    regcap.top_cor  = vec_in[35+:2];       
-    regcap.base_cor = vec_in[33+:2];       
-    regcap.exp      = vec_in[28+:EXP_W];   
-    regcap.top      = vec_in[19+:TOP_W];   
-    regcap.base     = vec_in[10+:BOT_W];   
-    regcap.otype    = vec_in[7+:OTYPE_W];  
-    regcap.rsvd     = vec_in[6+:1];  
-    regcap.cperms   = vec_in[0+:CPERMS_W]; 
+    regcap.valid    = vec_in[REGCAP_W-1];
+    regcap.top_cor  = vec_in[35+:2];
+    regcap.base_cor = vec_in[33+:2];
+    regcap.exp      = vec_in[28+:EXP_W];
+    regcap.top      = vec_in[19+:TOP_W];
+    regcap.base     = vec_in[10+:BOT_W];
+    regcap.otype    = vec_in[7+:OTYPE_W];
+    regcap.rsvd     = vec_in[6+:1];
+    regcap.cperms   = vec_in[0+:CPERMS_W];
 
     return regcap;
   endfunction
 
   // test whether 2 caps are equal
-  function automatic logic is_equal (full_cap_t cap_a, full_cap_t cap_b, 
+  function automatic logic is_equal (full_cap_t cap_a, full_cap_t cap_b,
                                      logic [31:0] addra, logic[31:0] addrb);
 
     is_equal =  (cap_a.valid  == cap_b.valid) &&
                 (cap_a.top  == cap_b.top) && (cap_a.base == cap_b.base) &&
-                (cap_a.cperms  == cap_b.cperms) && (cap_a.rsvd == cap_b.rsvd) && 
-                (cap_a.exp    == cap_b.exp) && (cap_a.otype  == cap_b.otype) && 
+                (cap_a.cperms  == cap_b.cperms) && (cap_a.rsvd == cap_b.rsvd) &&
+                (cap_a.exp    == cap_b.exp) && (cap_a.otype  == cap_b.otype) &&
                 (addra == addrb);
     return is_equal;
 
@@ -859,11 +859,11 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
   parameter logic [3:0] PVIO_ASR   = 4'h6;
   parameter logic [3:0] PVIO_ALIGN = 4'h7;
   parameter logic [3:0] PVIO_SLC   = 4'h8;
-  
+
 
   function automatic logic [4:0] vio_cause_enc (logic bound_vio, logic[W_PVIO-1:0] perm_vio_vec);
     logic [4:0] vio_cause;
-    
+
     if (perm_vio_vec[PVIO_TAG])
       vio_cause = 5'h2;
     else if (perm_vio_vec[PVIO_SEAL])
@@ -887,5 +887,5 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
     return vio_cause;
   endfunction
- 
+
 endpackage

--- a/rtl/cheri_regfile.sv
+++ b/rtl/cheri_regfile.sv
@@ -1,4 +1,3 @@
-
 // Copyright Microsoft Corporation
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -37,11 +36,11 @@ module cheri_regfile import cheri_pkg::*; #(
   input  logic          [4:0]   trvk_addr_i,
   input  logic                  trvk_en_i,
   input  logic                  trvk_clrtag_i,
-  input  logic          [6:0]   trvk_par_i,     // make sure this is included in lockstep compare      
+  input  logic          [6:0]   trvk_par_i,     // make sure this is included in lockstep compare
   input  logic          [4:0]   trsv_addr_i,
   input  logic                  trsv_en_i,
-  input  logic          [6:0]   trsv_par_i,     
-  
+  input  logic          [6:0]   trsv_par_i,
+
   output logic                  alert_o
 );
 
@@ -55,10 +54,10 @@ module cheri_regfile import cheri_pkg::*; #(
 
   logic [31:0] rf_reg   [NREGS-1:0];
   logic [31:0] rf_reg_q [NREGS-1:1];
-  
+
   logic [6:0]  rf_reg_par   [NREGS-1:0];
   logic [6:0]  rf_reg_par_q [NREGS-1:0];
-  
+
   reg_cap_t         rf_cap   [NCAPS-1:0];
   reg_cap_t         rf_cap_q [NCAPS-1:1];
 
@@ -67,9 +66,9 @@ module cheri_regfile import cheri_pkg::*; #(
   logic [NREGS-1:1] we_a_dec;
   logic [NREGS-1:1] trvk_dec, trsv_dec;
   logic [31:0]      reg_rdy_vec;
-  
+
   logic             pplbc_alert;
-  
+
   always_comb begin : we_a_decoder
     for (int unsigned i = 1; i < NREGS; i++) begin
       we_a_dec[i] = (waddr_a_i == 5'(i)) ? we_a_i : 1'b0;
@@ -81,21 +80,21 @@ module cheri_regfile import cheri_pkg::*; #(
   // No flops for R0 as it's hard-wired to 0
   for (genvar i = 1; i < NREGS; i++) begin : g_rf_flops
     logic cap_valid;
-    
-    
+
+
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         rf_reg_q[i] <= 32'h0;
       end else if (we_a_dec[i]) begin
         rf_reg_q[i] <= wdata_a_i[31:0];
-      end 
+      end
     end
-    
+
     if (RegFileECC) begin : g_reg_par
       logic [6:0] wdata_par;
-      
+
       assign wdata_par = wdata_a_i[DataWidth-1:DataWidth-7];
-      
+
       // split reset of data and parity to detect spurious reset (fault protection)
       always_ff @(posedge clk_i or negedge par_rst_ni) begin
         if (!par_rst_ni) begin
@@ -105,7 +104,7 @@ module cheri_regfile import cheri_pkg::*; #(
           rf_reg_par_q[i] <= rf_reg_par_q[i] ^ TrvkParIncr;
         end else if (we_a_dec[i]) begin
           rf_reg_par_q[i] <= wdata_par;
-        end 
+        end
       end
     end else begin : g_no_reg_par
       assign rf_reg_par_q[i] = 7'h0;
@@ -117,8 +116,8 @@ module cheri_regfile import cheri_pkg::*; #(
   assign rf_reg[0]     = 32'h0;
   assign rf_reg_par[0] = DefParBits[0];
   for (genvar i=1; i<NREGS ; i++) begin
-    assign rf_reg[i]     = rf_reg_q[i];         
-    assign rf_reg_par[i] = rf_reg_par_q[i];     
+    assign rf_reg[i]     = rf_reg_q[i];
+    assign rf_reg_par[i] = rf_reg_par_q[i];
   end
 
   assign rdata_a_o = {rf_reg_par[raddr_a_i], rf_reg[raddr_a_i]};
@@ -151,12 +150,12 @@ module cheri_regfile import cheri_pkg::*; #(
 // QQQ_09112023 (contention when TRVKBypass=1)
 //   Note, when 33-bit memory bus is used, trsv and trvk should NEVER point to the same register
 //   -- trsv_en and trvk_en could active in the same cycle but should be pointing to different registers
-//   -- since trsv_en can only be asserted by CLC&lsu_req_done. Even in trvk_bypass case, trsv can only 
+//   -- since trsv_en can only be asserted by CLC&lsu_req_done. Even in trvk_bypass case, trsv can only
 //   -- happen 1 cycle later than trvk_en (to the same register)
 //   However when 65-bit memory is used, trsv and trvk can point to the same register at the same time
 //   -- here lsu_req/req_done happens at the same time as the bypassed TRVK uninstall the instruction.
 //   -- to resolve the contention we need to prioritize trsv over trvk when updating the flopped reg_rdy_vec
-    
+
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni)
         reg_rdy_vec[0] <= 1'b1;
@@ -166,7 +165,7 @@ module cheri_regfile import cheri_pkg::*; #(
       always_ff @(posedge clk_i or negedge rst_ni) begin
         if (!rst_ni)
           reg_rdy_vec[i] <= 1'b1;
-        else if (i >= NCAPS) 
+        else if (i >= NCAPS)
           reg_rdy_vec[i] <= 1'b1;
         else if (trsv_dec[i] & trsv_en_i)   // prioritize trsv to address the corner case in the QQQ_09112023
           reg_rdy_vec[i] <= 1'b0;
@@ -185,24 +184,24 @@ module cheri_regfile import cheri_pkg::*; #(
       logic        trsv_en_q;
       logic  [6:0] trsv_par_q;
 
-      logic      [31:0] reg_rdy_vec_shdw, reg_rdy_vec_q;  
+      logic      [31:0] reg_rdy_vec_shdw, reg_rdy_vec_q;
       logic [NREGS-1:1] trvk_dec_shdw, trsv_dec_shdw;
-      logic             shdw_mismatch_err, cap_rvk_err;            
+      logic             shdw_mismatch_err, cap_rvk_err;
 
 
-      always_comb begin  
+      always_comb begin
         for (int unsigned i = 1; i < NREGS; i++) begin
           trvk_dec_shdw[i] = (trvk_addr_q == 5'(i));
           trsv_dec_shdw[i] = (trsv_addr_q == 5'(i));
         end
       end
-      
+
       always_ff @(posedge clk_i or negedge par_rst_ni) begin
         if (!par_rst_ni) begin
            trvk_addr_q   <= 5'h0;
-           trvk_en_q     <= 1'b0;        
+           trvk_en_q     <= 1'b0;
            trvk_clrtag_q <= 1'b0;
-           trvk_par_q    <= NullParBits;   
+           trvk_par_q    <= NullParBits;
            trsv_addr_q   <= 5'h0;
            trsv_en_q     <= 1'b0;
            trsv_par_q    <= NullParBits;
@@ -211,14 +210,14 @@ module cheri_regfile import cheri_pkg::*; #(
            trvk_addr_q   <= trvk_addr_i;
            trvk_en_q     <= trvk_en_i;
            trvk_clrtag_q <= trvk_clrtag_i;
-           trvk_par_q    <= trvk_par_i;   
+           trvk_par_q    <= trvk_par_i;
            trsv_addr_q   <= trsv_addr_i;
            trsv_en_q     <= trsv_en_i;
            trsv_par_q    <= trsv_par_i;
            reg_rdy_vec_q <= reg_rdy_vec;
         end
       end
-      
+
       for (genvar i = 0; i < 32; i++) begin
         if ((i == 0) || (i >= NCAPS)) begin
           assign reg_rdy_vec_shdw[i] = 1'b1;
@@ -234,18 +233,18 @@ module cheri_regfile import cheri_pkg::*; #(
         end
       end
 
-      // generate alert 
+      // generate alert
       assign shdw_mismatch_err = (reg_rdy_vec_shdw != reg_rdy_vec_q);
 
       // readback revoked cap to make sure the valid bit is actually cleared
       always_comb begin
-        cap_rvk_err = 0;        
+        cap_rvk_err = 0;
         for (int unsigned i = 1; i < NCAPS; i++) begin
           cap_rvk_err = cap_rvk_err | (trvk_en_q & trvk_clrtag_q & trvk_dec_shdw[i] & rf_cap_q[i].valid);
         end
       end
- 
-       
+
+
       // check parity of trsv and trvk requests
       logic [1:0] trsv_ecc_err, trvk_ecc_err;
 
@@ -264,21 +263,21 @@ module cheri_regfile import cheri_pkg::*; #(
       );
 
       assign pplbc_alert = shdw_mismatch_err | cap_rvk_err | (|trsv_ecc_err) | (|trvk_ecc_err);
-      
+
     end else begin : gen_no_shdw // no ECC or shdw checking
-      assign pplbc_alert = 1'b0;      
+      assign pplbc_alert = 1'b0;
     end
-    
+
   end else begin : g_no_regrdy
     assign reg_rdy_vec = {32{1'b1}};
     assign pplbc_alert = 1'b0;
   end  // not pplbc
-  
+
   //
   //  read back last-writen register for fault protection
   //
   logic reg_rdbk_err;
-  
+
   if (RegFileECC) begin : gen_fault_rdbk
     logic [NREGS-1:1] we_a_dec_shdw;
     logic       [4:0] waddr_a_q;
@@ -290,8 +289,8 @@ module cheri_regfile import cheri_pkg::*; #(
     logic       [6:0] rpar_tmp;
     logic       [1:0] wreq_ecc_err;
     logic             rdbk_cmp_err;
-    
-    // flop the write request and check parity 
+
+    // flop the write request and check parity
     //   need all fields to compute parity bits
     always_ff @(posedge clk_i or negedge par_rst_ni) begin
       if (!par_rst_ni) begin
@@ -307,7 +306,7 @@ module cheri_regfile import cheri_pkg::*; #(
         wcap_vec_q  <= reg2vec(wcap_a_i);
         we_a_q      <= we_a_i;
       end
-    end      
+    end
 
     assign wdata_tmp    = wdata_a_q ^ wcap_vec_q[31:0] ^ {20'h0, we_a_q, waddr_a_q, wcap_vec_q[37:32]};
 
@@ -317,24 +316,24 @@ module cheri_regfile import cheri_pkg::*; #(
       .syndrome_o(),
       .err_o     (wreq_ecc_err)
     );
-   
+
     // decode and read back to verify (only parity bits)
-    always_comb begin 
+    always_comb begin
       for (int unsigned i = 1; i < NREGS; i++) begin
         we_a_dec_shdw[i] = (waddr_a_q == 5'(i)) ? we_a_q : 1'b0;
       end
     end
 
-    assign rpar_tmp     = rf_reg_par[waddr_a_q]; 
-   
+    assign rpar_tmp     = rf_reg_par[waddr_a_q];
+
     assign rdbk_cmp_err = (rpar_tmp != wpar_a_q) && (waddr_a_q != 0) && we_a_q;
 
     assign reg_rdbk_err = (|wreq_ecc_err) | rdbk_cmp_err;
 
   end else begin : gen_no_fault_rdbk
     assign reg_rdbk_err = 1'b0;
-  end 
-  
+  end
+
   assign alert_o   = pplbc_alert | reg_rdbk_err;
 
   reg_cap_t rcap_a_rvkd, rcap_b_rvkd;
@@ -343,7 +342,7 @@ module cheri_regfile import cheri_pkg::*; #(
     // Bypass the registier update cycle and directly update the read ports
     always_comb begin
       reg_rdy_o = reg_rdy_vec | ({NREGS{trvk_en_i}} & {trvk_dec, 1'b0});
-      
+
       rcap_a_rvkd = rcap_a;
       if (trvk_en_i && trvk_clrtag_i && (trvk_addr_i == raddr_a_i))
         rcap_a_rvkd.valid = 1'b0;
@@ -353,7 +352,7 @@ module cheri_regfile import cheri_pkg::*; #(
       if (trvk_en_i && trvk_clrtag_i && (trvk_addr_i == raddr_b_i))
         rcap_b_rvkd.valid = 1'b0;
       rcap_b_o = rcap_b_rvkd;
-    
+
     end
   end else begin
     assign reg_rdy_o = reg_rdy_vec;
@@ -363,7 +362,7 @@ module cheri_regfile import cheri_pkg::*; #(
     assign rcap_b_rvkd = rcap_b;
     assign rcap_b_o  = rcap_b_rvkd;
   end
-   
+
 
 
 endmodule

--- a/rtl/cheri_tbre_wrapper.sv
+++ b/rtl/cheri_tbre_wrapper.sv
@@ -10,13 +10,13 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   parameter  bit         StkZIntrOK  = 1'b0,
   parameter int unsigned MMRegDinW   = 128,
   parameter int unsigned MMRegDoutW  = 64
-  
+
 ) (
    // Clock and Reset
   input  logic          clk_i,
   input  logic          rst_ni,
 
-  // MMIO register interface 
+  // MMIO register interface
   input  logic [MMRegDinW-1:0]  mmreg_corein_i,
   output logic [MMRegDoutW-1:0] mmreg_coreout_o,
 
@@ -24,8 +24,8 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   input  logic          lsu_tbre_resp_valid_i,
   input  logic          lsu_tbre_resp_err_i,
   input  logic          lsu_tbre_resp_is_wr_i,
-  input  logic [32:0]   lsu_tbre_raw_lsw_i,   
-  input  logic          lsu_tbre_req_done_i,   
+  input  logic [32:0]   lsu_tbre_raw_lsw_i,
+  input  logic          lsu_tbre_req_done_i,
   input  logic          lsu_tbre_addr_incr_i,
   output logic          tbre_lsu_req_o,
   output logic          tbre_lsu_is_cap_o,
@@ -34,7 +34,7 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   output logic [32:0]   tbre_lsu_wdata_o,
 
   // LSU snoop interface
-  input  logic          snoop_lsu_req_done_i,   
+  input  logic          snoop_lsu_req_done_i,
   input  logic          snoop_lsu_req_i,
   input  logic          snoop_lsu_is_cap_i,
   input  logic          snoop_lsu_we_i,
@@ -51,7 +51,7 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   input  full_cap_t     ztop_wfcap_i,
   output logic [31:0]   ztop_rdata_o,
   output reg_cap_t      ztop_rcap_o,
- 
+
   input  logic          unmasked_intr_i,
 
   output logic          stkz_active_o,
@@ -62,16 +62,16 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
 
   localparam nMSTR = 2;
 
-  logic          lsu_blk1_resp_valid;    
-  logic          lsu_blk1_req_done;   
+  logic          lsu_blk1_resp_valid;
+  logic          lsu_blk1_req_done;
   logic          blk1_lsu_req;
   logic          blk1_lsu_is_cap;
   logic          blk1_lsu_we;
   logic [31:0]   blk1_lsu_addr;
   logic [32:0]   blk1_lsu_wdata;
 
-  logic          lsu_blk0_resp_valid;    
-  logic          lsu_blk0_req_done;   
+  logic          lsu_blk0_resp_valid;
+  logic          lsu_blk0_req_done;
   logic          blk0_lsu_req;
   logic          blk0_lsu_is_cap;
   logic          blk0_lsu_we;
@@ -90,11 +90,11 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
     assign tbre_ctrl_vec      = mmreg_corein_i[65:0];
 
     cheri_tbre #(
-      .FifoSize (4), 
+      .FifoSize (4),
       .AddrHi   (23)
     ) cheri_tbre_i (
      // Clock and Reset
-      .clk_i                   (clk_i),                 
+      .clk_i                   (clk_i),
       .rst_ni                  (rst_ni),
       .tbre_ctrl_vec_i         (tbre_ctrl_vec),
       .tbre_stat_o             (tbre_stat),
@@ -102,22 +102,22 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
       .lsu_tbre_resp_valid_i   (lsu_blk1_resp_valid),
       .lsu_tbre_resp_err_i     (lsu_tbre_resp_err_i),
       .lsu_tbre_resp_is_wr_i   (lsu_tbre_resp_is_wr_i),
-      .lsu_tbre_raw_lsw_i      (lsu_tbre_raw_lsw_i),   
-      .lsu_tbre_req_done_i     (lsu_blk1_req_done),   
+      .lsu_tbre_raw_lsw_i      (lsu_tbre_raw_lsw_i),
+      .lsu_tbre_req_done_i     (lsu_blk1_req_done),
       .lsu_tbre_addr_incr_i    (lsu_tbre_addr_incr_i),
       .tbre_lsu_req_o          (blk1_lsu_req),
       .tbre_lsu_is_cap_o       (blk1_lsu_is_cap),
       .tbre_lsu_we_o           (blk1_lsu_we),
       .tbre_lsu_addr_o         (blk1_lsu_addr),
       .tbre_lsu_wdata_o        (blk1_lsu_wdata),
-      .snoop_lsu_req_done_i    (snoop_lsu_req_done_i),  
+      .snoop_lsu_req_done_i    (snoop_lsu_req_done_i),
       .snoop_lsu_req_i         (snoop_lsu_req_i),
       .snoop_lsu_is_cap_i      (snoop_lsu_is_cap_i),
       .snoop_lsu_we_i          (snoop_lsu_we_i),
       .snoop_lsu_cheri_err_i   (snoop_lsu_cheri_err_i),
       .snoop_lsu_addr_i        (snoop_lsu_addr_i),
       .trvk_en_i               (trvk_en_i),
-      .trvk_clrtag_i           (trvk_clrtag_i)          
+      .trvk_clrtag_i           (trvk_clrtag_i)
       );
   end else begin
     assign tbre_stat       = 1'b0;
@@ -136,7 +136,7 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
     cheri_stkz cheri_stkz_i (
       .clk_i                  (clk_i             ),
       .rst_ni                 (rst_ni            ),
-      .ztop_wr_i              (ztop_wr_i),  
+      .ztop_wr_i              (ztop_wr_i),
       .ztop_wdata_i           (ztop_wdata_i),
       .ztop_wfcap_i           (ztop_wfcap_i),
       .ztop_rdata_o           (ztop_rdata_o),
@@ -188,15 +188,15 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   // arbitration by strict priority assignment - mst_req[0] == highest priority
   for (genvar i = 0; i < nMSTR; i++) begin
     logic [7:0] pri_mask;
-    assign pri_mask = 8'hff >> (8-i);      // max 8 masters, should be enough 
+    assign pri_mask = 8'hff >> (8-i);      // max 8 masters, should be enough
     assign mstr_arbit[i] = mstr_req[i] & ~(|(mstr_req & pri_mask));
   end
 
-  // Handling delayed-gnt case. 
+  // Handling delayed-gnt case.
   // make the next arbiration decision immediately if any master_req active
-  // If slv_gnt doesn't happen in the same cycle, register the  decision till 
-  // slv_gant so that the address/wdata/ctrl can be hold steady when presenting 
-  // the next request to the slave. 
+  // If slv_gnt doesn't happen in the same cycle, register the  decision till
+  // slv_gant so that the address/wdata/ctrl can be hold steady when presenting
+  // the next request to the slave.
   assign mstr_arbit_comb = req_pending_q ? mstr_arbit_q : mstr_arbit;
   assign req_pending = |mstr_req & ~slv_gnt & ~req_pending_q;
 
@@ -221,10 +221,10 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   assign tbre_lsu_addr_o    = mstr_arbit_comb[1] ? blk1_lsu_addr : blk0_lsu_addr;
   assign tbre_lsu_wdata_o   = mstr_arbit_comb[1] ? blk1_lsu_wdata : blk0_lsu_wdata;
 
-  assign lsu_blk1_req_done  = mstr_arbit_comb[1] & lsu_tbre_req_done_i; 
-  assign lsu_blk0_req_done  = mstr_arbit_comb[0] & lsu_tbre_req_done_i; 
+  assign lsu_blk1_req_done  = mstr_arbit_comb[1] & lsu_tbre_req_done_i;
+  assign lsu_blk0_req_done  = mstr_arbit_comb[0] & lsu_tbre_req_done_i;
 
-  // 
+  //
   logic resp_sel_q;
   always @(posedge clk_i or negedge rst_ni) begin
     if(~rst_ni) begin

--- a/rtl/cheri_trvk_stage.sv
+++ b/rtl/cheri_trvk_stage.sv
@@ -61,7 +61,7 @@ module cheri_trvk_stage #(
   assign tsmap_addr_o  = tsmap_ptr[15:5];
 
   // not a sealling cap and pointing to valid TSMAP range
-  assign range_ok      = (tsmap_ptr[31:5] <= TSMapSize) && 
+  assign range_ok      = (tsmap_ptr[31:5] <= TSMapSize) &&
                          ~((in_cap_q.cperms[4:3]==2'b00) && (|in_cap_q.cperms[2:0]));
   assign tsmap_cs_o    = (cpu_op_valid_q[0] | tbre_op_valid_q[0]) & cap_good_q[0];
 
@@ -84,8 +84,8 @@ module cheri_trvk_stage #(
     end
   end
 
-  
-  assign cpu_op_valid  =  cpu_op_active & lsu_resp_valid_i;    // CPU op only active when Load cap 
+
+  assign cpu_op_valid  =  cpu_op_active & lsu_resp_valid_i;    // CPU op only active when Load cap
   assign tbre_op_valid =  lsu_tbre_resp_valid_i & ~lsu_resp_is_wr_i;    // TBRE Load
   assign cap_good      =  (cpu_op_active & lsu_resp_valid_i & ~lsu_load_err_i & rf_wcap_lsu_i.valid) |
                           (lsu_tbre_resp_valid_i & ~lsu_tbre_resp_err_i &  rf_wcap_lsu_i.valid);

--- a/rtl/ibex_compressed_decoder.sv
+++ b/rtl/ibex_compressed_decoder.sv
@@ -266,7 +266,7 @@ module ibex_compressed_decoder # (
             end else begin
               instr_o = instr_i;
               illegal_instr_o = 1'b1;
-            end 
+            end
           end
 
           3'b100: begin
@@ -308,7 +308,7 @@ module ibex_compressed_decoder # (
               // c.cscsp -> csc cs2, imm(c2),  reuse c.sdsp
               instr_o = {3'b0, instr_i[9:7], instr_i[12], instr_i[6:2], 5'h02, 3'b011,
                          instr_i[11:10], 3'b000, {OPCODE_STORE}};
-            end else begin 
+            end else begin
               instr_o = instr_i;
               illegal_instr_o = 1'b1;
             end

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -234,7 +234,7 @@ module ibex_controller #(
   // to pc_set_o.  Clear when controller is in FLUSH so it won't remain set
   // once illegal instruction is handled.
   // All terms in this expression are qualified by instr_valid_i
-  assign illegal_insn_d = (illegal_insn_i | illegal_dret | illegal_umode | (cheri_pmode_i & illegal_mret_cheri)) & 
+  assign illegal_insn_d = (illegal_insn_i | illegal_dret | illegal_umode | (cheri_pmode_i & illegal_mret_cheri)) &
                           (ctrl_fsm_cs != FLUSH);
   assign cheri_ex_err_d = cheri_pmode_i & cheri_ex_err & (ctrl_fsm_cs != FLUSH);
 
@@ -764,7 +764,7 @@ module ibex_controller #(
                   exc_cause_o = EXC_CAUSE_STORE_ADDR_MISALIGN;
                   csr_mtval_o = lsu_addr_last_i;
                 end else begin
-                  exc_cause_o = EXC_CAUSE_CHERI_FAULT; 
+                  exc_cause_o = EXC_CAUSE_CHERI_FAULT;
                   csr_mtval_o = cheri_wb_err_info_i[10:0];
                 end
               end else begin
@@ -789,7 +789,7 @@ module ibex_controller #(
             cheri_ex_err_prio: begin
               if (cheri_pmode_i) begin
                 exc_cause_o = EXC_CAUSE_CHERI_FAULT;
-                csr_mtval_o = cheri_ex_err_info_i[10:0];        
+                csr_mtval_o = cheri_ex_err_info_i[10:0];
               end
             end
             cheri_wb_err_prio: begin

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -473,8 +473,8 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
   logic          lsu_tbre_resp_valid;
   logic          lsu_tbre_resp_err;
   logic          lsu_resp_is_wr;
-  logic [32:0]   lsu_tbre_raw_lsw;   
-  logic          lsu_tbre_req_done;   
+  logic [32:0]   lsu_tbre_raw_lsw;
+  logic          lsu_tbre_req_done;
   logic          lsu_tbre_addr_incr;
   logic          tbre_lsu_req;
   logic          tbre_lsu_is_cap;
@@ -487,7 +487,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
   logic          lsu_tbre_sel, cpu_lsu_dec;
   logic          rf_trsv_en;
 
-  
+
 
 
   //////////////////////
@@ -944,7 +944,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
       .tbre_lsu_we_i        (tbre_lsu_we),
       .tbre_lsu_addr_i      (tbre_lsu_addr),
       .tbre_lsu_wdata_i     (tbre_lsu_wdata),
-      .cpu_lsu_dec_o        (cpu_lsu_dec),  
+      .cpu_lsu_dec_o        (cpu_lsu_dec),
       .csr_rdata_i          (cheri_csr_rdata),
       .csr_rcap_i           (cheri_csr_rcap),
       .csr_mstatus_mie_i    (csr_mstatus_mie),
@@ -964,7 +964,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
       .stkz_abort_i         (stkz_abort),
       .stkz_ptr_i           (stkz_ptr),
       .stkz_base_i          (stkz_base),
-      .ztop_wr_o            (ztop_wr),  
+      .ztop_wr_o            (ztop_wr),
       .ztop_wdata_o         (ztop_wdata),
       .ztop_wfcap_o         (ztop_wfcap),
       .ztop_rdata_i         (ztop_rdata),
@@ -978,16 +978,16 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
   end else begin : gen_no_cheri_ex
     assign rf_trsv_en_o           = 1'b0;
     assign rf_trsv_addr_o         = 5'h0;
-                                  
+
     assign cheri_branch_req       = 1'b0;
     assign cheri_branch_req_spec  = 1'b0;
     assign branch_target_ex       = branch_target_ex_rv32;
     assign pcc_cap_w              = NULL_PCC_CAP;
-                                  
+
     assign cheri_rf_we            = 1'b0;
     assign cheri_result_data      = 32'h0;
     assign cheri_result_cap       = NULL_REG_CAP;
-                                  
+
     assign cheri_ex_valid         = 1'b0;
     assign cheri_ex_err           = 1'b0;
     assign cheri_ex_err_info      = 11'h0;
@@ -1017,10 +1017,10 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     assign cheri_csr_op_en        = 1'b0;
     assign cheri_csr_set_mie      = 1'b0;
     assign cheri_csr_clr_mie      = 1'b0;
-     
+
     assign csr_mshwm_set          = 1'b0;
     assign csr_mshwm_new          = 1'b0;
- 
+
   end
 
   /////////////////////////////
@@ -1048,7 +1048,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     .rf_trvk_en_o      (rf_trvk_en_o    ),
     .rf_trvk_clrtag_o  (rf_trvk_clrtag_o),
     .tbre_trvk_en_o    (tbre_trvk_en    ),
-    .tbre_trvk_clrtag_o(tbre_trvk_clrtag),          
+    .tbre_trvk_clrtag_o(tbre_trvk_clrtag),
     .tsmap_cs_o        (tsmap_cs_o      ),
     .tsmap_addr_o      (tsmap_addr_o    ),
     .tsmap_rdata_i     (tsmap_rdata_i   )
@@ -1079,22 +1079,22 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     .MMRegDoutW  (MMRegDoutW)
   ) cheri_tbre_wrapper_i (
    // Clock and Reset
-    .clk_i                   (clk_i),                 
+    .clk_i                   (clk_i),
     .rst_ni                  (rst_ni),
     .mmreg_corein_i          (mmreg_corein_i),
     .mmreg_coreout_o         (mmreg_coreout_o),
     .lsu_tbre_resp_valid_i   (lsu_tbre_resp_valid),
     .lsu_tbre_resp_err_i     (lsu_tbre_resp_err),
     .lsu_tbre_resp_is_wr_i   (lsu_resp_is_wr),
-    .lsu_tbre_raw_lsw_i      (lsu_tbre_raw_lsw),   
-    .lsu_tbre_req_done_i     (lsu_tbre_req_done),   
+    .lsu_tbre_raw_lsw_i      (lsu_tbre_raw_lsw),
+    .lsu_tbre_req_done_i     (lsu_tbre_req_done),
     .lsu_tbre_addr_incr_i    (lsu_addr_incr_req),
     .tbre_lsu_req_o          (tbre_lsu_req),
     .tbre_lsu_is_cap_o       (tbre_lsu_is_cap),
     .tbre_lsu_we_o           (tbre_lsu_we),
     .tbre_lsu_addr_o         (tbre_lsu_addr),
     .tbre_lsu_wdata_o        (tbre_lsu_wdata),
-    .snoop_lsu_req_done_i    (snoop_lsu_req_done),  
+    .snoop_lsu_req_done_i    (snoop_lsu_req_done),
     .snoop_lsu_req_i         (lsu_req),
     .snoop_lsu_is_cap_i      (lsu_is_cap),
     .snoop_lsu_we_i          (lsu_we),
@@ -1102,7 +1102,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     .snoop_lsu_addr_i        (lsu_addr),
     .trvk_en_i               (tbre_trvk_en),
     .trvk_clrtag_i           (tbre_trvk_clrtag),
-    .ztop_wr_i               (ztop_wr),  
+    .ztop_wr_i               (ztop_wr),
     .ztop_wdata_i            (ztop_wdata),
     .ztop_wfcap_i            (ztop_wfcap),
     .ztop_rdata_o            (ztop_rdata),
@@ -1111,10 +1111,10 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     .stkz_active_o           (stkz_active),
     .stkz_abort_o            (stkz_abort),
     .stkz_ptr_o              (stkz_ptr),
-    .stkz_base_o             (stkz_base)          
+    .stkz_base_o             (stkz_base)
   ) ;
-   
-   
+
+
   /////////////////////
   // Load/store unit //
   /////////////////////
@@ -1177,11 +1177,11 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
     .lsu_req_done_intl_o (lsu_req_done_intl),
     .lsu_resp_valid_o (lsu_resp_valid),
     .lsu_resp_valid_intl_o(lsu_resp_valid_intl),
-    .lsu_resp_is_wr_o      (lsu_resp_is_wr),    
+    .lsu_resp_is_wr_o      (lsu_resp_is_wr),
 
     .tbre_lsu_req_i        (tbre_lsu_req),
     .cpu_lsu_dec_i         (cpu_lsu_dec),
-    .lsu_tbre_sel_o        (lsu_tbre_sel),     
+    .lsu_tbre_sel_o        (lsu_tbre_sel),
     .lsu_tbre_raw_lsw_o    (lsu_tbre_raw_lsw),
     .lsu_tbre_req_done_o   (lsu_tbre_req_done),
     .lsu_tbre_resp_valid_o (lsu_tbre_resp_valid),
@@ -1293,7 +1293,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
       .data_i({26'h0, rf_trsv_en_o, rf_trsv_addr_o}),
       .data_o({rf_trsv_par_o, unused_sig32_0})
     );
-    
+
     prim_secded_inv_39_32_enc trvk_ecc_enc (
       .data_i({25'h0, rf_trvk_en_o, rf_trvk_clrtag_o, rf_trvk_addr_o}),
       .data_o({rf_trvk_par_o, unused_sig32_1})
@@ -1305,7 +1305,7 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
 
     assign rdata_a_tmp = rf_rdata_a_ecc_i[31:0] ^ rf_rcap_a_vec[31:0] ^ {20'h0, 1'b1, rf_raddr_a, rf_rcap_a_vec[37:32]};
     assign rdata_b_tmp = rf_rdata_b_ecc_i[31:0] ^ rf_rcap_b_vec[31:0] ^ {20'h0, 1'b1, rf_raddr_b, rf_rcap_b_vec[37:32]};
-    
+
     //assign rdata_a_tmp = rf_rdata_a_ecc_i[31:0] ^ rf_rcap_a_vec[31:0] ^ {26'h0, rf_rcap_a_vec[37:32]};
     //assign rdata_b_tmp = rf_rdata_b_ecc_i[31:0] ^ rf_rcap_b_vec[31:0] ^ {26'h0, rf_rcap_b_vec[37:32]};
     prim_secded_inv_39_32_dec regfile_ecc_dec_a (
@@ -2096,7 +2096,7 @@ end
       end
     end
   end else begin
-    assign rvfi_rs1_cap_d  = NULL_REG_CAP; 
+    assign rvfi_rs1_cap_d  = NULL_REG_CAP;
     assign rvfi_rs2_cap_d  = NULL_REG_CAP;
   end
 
@@ -2184,8 +2184,8 @@ end
   always_comb begin
     rvfi_set_trap_pc_d = rvfi_set_trap_pc_q;
 
-    //if (pc_set && pc_mux_id == PC_EXC &&           // kliu - interrupt only 
-    //    (exc_pc_mux_id == EXC_PC_EXC || exc_pc_mux_id == EXC_PC_IRQ)) begin   
+    //if (pc_set && pc_mux_id == PC_EXC &&           // kliu - interrupt only
+    //    (exc_pc_mux_id == EXC_PC_EXC || exc_pc_mux_id == EXC_PC_IRQ)) begin
     if (pc_set && pc_mux_id == PC_EXC && (exc_pc_mux_id == EXC_PC_IRQ)) begin
       // PC is set to enter a trap handler
       rvfi_set_trap_pc_d = 1'b1;

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -861,13 +861,13 @@ module ibex_cs_registers import cheri_pkg::*;  #(
 
   // only write CSRs during one clock cycle
 
-  // enforcing the CHERI CSR access policy. 
+  // enforcing the CHERI CSR access policy.
   //  -- is reading zero back ok? or do we need to generate illegal access exception??
   //  -- also note IBEX didn't implement user-mode TIME/counters.
   //     for now we are allowing reading the M-mode counters (assuming only use single priv level)
 
   logic read_ok;
-  assign read_ok = ~CHERIoTEn || ~cheri_pmode_i || debug_mode_i || pcc_cap_q.perms[PERM_SR] || 
+  assign read_ok = ~CHERIoTEn || ~cheri_pmode_i || debug_mode_i || pcc_cap_q.perms[PERM_SR] ||
                    ((csr_addr_i>=CSR_MCYCLE) && (csr_addr_i<=CSR_CDBG_CTRL));
                    // ((csr_addr_i>=CSR_MCYCLE) && (csr_addr_i<CSR_MSHWM));
 
@@ -1009,7 +1009,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
   assign mtvec_en_combi = mtvec_en | mtvec_en_cheri;
 
   // use only 2'b00 (direct mode) for CHERIoT
-  assign mtvec_d_combi = ({32{mtvec_en}} & mtvec_d) | ({32{mtvec_en_cheri}} & 
+  assign mtvec_d_combi = ({32{mtvec_en}} & mtvec_d) | ({32{mtvec_en_cheri}} &
                           {cheri_csr_wdata_i[31:2],2'b00});
 
   // MTVEC
@@ -1851,7 +1851,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
       full_cap_t   tf_cap;
       reg_cap_t    tr_cap;
       logic [31:0] tr_addr;
-     
+
       if (csr_save_cause_i) begin              // Exception cases
         tr_cap  = mtvec_cap;
         tr_addr = mtvec_q;
@@ -1869,7 +1869,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
       tf_cap = reg2fullcap(tr_cap, tr_addr);
 
       // Exception cases
-      if (csr_save_cause_i | csr_restore_mret_i | (csr_restore_dret_i & debug_mode_i)) begin 
+      if (csr_save_cause_i | csr_restore_mret_i | (csr_restore_dret_i & debug_mode_i)) begin
         pcc_cap_d = full2pcap(tf_cap);
       end else if (cheri_branch_req_i) begin
         pcc_cap_d = pcc_cap_i;
@@ -1893,7 +1893,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
 
     // let's not worry about non-stanard recoverable NMI/mstack for now QQQ
     //   note we need to do set_address (representability check) when saving pcc_cap to mepc
-    //   otherwise an out-of-bound pcc_cap may cause mepc corruption 
+    //   otherwise an out-of-bound pcc_cap may cause mepc corruption
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni)
         mepc_cap <= MEPC_RESET_CAP;
@@ -1959,7 +1959,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
     end
 
   end else begin: gen_no_scr
-    
+
     assign cheri_csr_rdata_o = 32'h0;
     assign cheri_csr_rcap_o  = NULL_REG_CAP;
 

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -375,10 +375,10 @@ module ibex_decoder import cheri_pkg::*; #(
         if (instr[14]) begin
           illegal_insn     = 1'b1;
         end else if (instr[13:12] == 2'b11) begin
-          if (CHERIoTEn & cheri_pmode_i) begin 
+          if (CHERIoTEn & cheri_pmode_i) begin
             cheri_cstore_en  =  ~illegal_c_insn_i; // csc
             cheri_data_req_o =  ~illegal_c_insn_i;
-            data_req_o       =  1'b0; 
+            data_req_o       =  1'b0;
             illegal_insn     =  1'b0;
           end else begin
             cheri_cstore_en  =  1'b0; // csc
@@ -416,7 +416,7 @@ module ibex_decoder import cheri_pkg::*; #(
             end
           end
           2'b11: begin
-            // illegal_c_insn_i is added to fix the c.clcsp case 
+            // illegal_c_insn_i is added to fix the c.clcsp case
             //   (compressed decoder translate to cheri instruction but could still assert illegal_c_insn
             //   if rd == 0
             if (CHERIoTEn & cheri_pmode_i && ~instr[14] && ~illegal_c_insn_i) begin
@@ -1372,11 +1372,11 @@ module ibex_decoder import cheri_pkg::*; #(
     assign cheri_imm21_o          = 21'h0;
     assign cheri_operator_o       = 'h0;
     assign cheri_cs2_dec_o        = 1'b0;
-    assign cheri_rf_ren_a         = 1'b0;    
+    assign cheri_rf_ren_a         = 1'b0;
     assign cheri_rf_ren_b         = 1'b0;
     assign cheri_rf_we_dec_o      = 1'b0;
     assign cheri_multicycle_dec_o = 1'b0;
- 
+
   end
 
   ////////////////a

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -37,7 +37,7 @@ module ibex_id_stage import cheri_pkg::*; #(
   input  logic                      rst_ni,
 
   input  logic                      cheri_pmode_i,
-  input  logic                      cheri_tsafe_en_i,    
+  input  logic                      cheri_tsafe_en_i,
   output logic                      ctrl_busy_o,
   output logic                      illegal_insn_o,
 
@@ -140,7 +140,7 @@ module ibex_id_stage import cheri_pkg::*; #(
 
   input  logic                      lsu_load_err_i,
   input  logic                      lsu_store_err_i,
-  input  logic                      lsu_err_is_cheri_i, 
+  input  logic                      lsu_err_is_cheri_i,
 
   // Debug Signal
   output logic                      debug_mode_o,
@@ -722,7 +722,7 @@ module ibex_id_stage import cheri_pkg::*; #(
   // access is illegal. A combinational loop would be created if csr_op_en_o was used along (as
   // asserting it for an illegal csr access would result in a flush that would need to deassert it).
   // assign csr_op_en_o             = csr_access_o & instr_executing & instr_id_done_o;
-  assign csr_op_en_o             = csr_access_o & instr_executing & 
+  assign csr_op_en_o             = csr_access_o & instr_executing &
                                    ((CHERIoTEn & cheri_pmode_i) ? instr_first_cycle : instr_id_done_o);
 // QQQQQQQ KLIU - this needs to be looked into!!!!
 
@@ -1105,7 +1105,7 @@ module ibex_id_stage import cheri_pkg::*; #(
 
     assign stall_ld_hz = outstanding_load_wb_i & (rf_rd_a_hz | rf_rd_b_hz);
 
-    assign stall_cheri_trvk = (CHERIoTEn & cheri_pmode_i & CheriPPLBC) ? 
+    assign stall_cheri_trvk = (CHERIoTEn & cheri_pmode_i & CheriPPLBC) ?
                                ((rf_ren_a && ~rf_reg_rdy_i[rf_raddr_a_o]) |
                                 (rf_ren_b && ~rf_reg_rdy_i[rf_raddr_b_o]) |
                                 (cheri_rf_we && ~ rf_reg_rdy_i[rf_waddr_id_o])) :

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -366,7 +366,7 @@ module ibex_if_stage import ibex_pkg::*; import cheri_pkg::*; #(
   // only issue cheri_acc_vio on valid fetches
   assign cheri_acc_vio = CHERIoTEn & cheri_pmode_i & ~debug_mode_i & fetch_valid & ~fetch_err &
                         ((if_instr_addr < pcc_cap_i.base32) || instr_hdrm[32] || ~hdrm_ok  ||
-                         ~pcc_cap_i.perms[PERM_EX] || ~pcc_cap_i.valid || 
+                         ~pcc_cap_i.perms[PERM_EX] || ~pcc_cap_i.valid ||
                          (pcc_cap_i.otype!=0));
 
   // compressed instruction decoding, or more precisely compressed instruction

--- a/rtl/ibex_load_store_unit.sv
+++ b/rtl/ibex_load_store_unit.sv
@@ -79,7 +79,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
   output logic         lsu_tbre_sel_o,        // request-side selection signal
   output logic [32:0]  lsu_tbre_raw_lsw_o,
   output logic         lsu_tbre_req_done_o,
-  output logic         lsu_tbre_resp_valid_o, // response from transaction -> to TBRE 
+  output logic         lsu_tbre_resp_valid_o, // response from transaction -> to TBRE
   output logic         lsu_tbre_resp_err_o,
 
   // exception signals
@@ -430,7 +430,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
 
         if (CHERIoTEn & cheri_pmode_i & lsu_req_i & lsu_cheri_err_i & ~resp_wait) begin
           // cheri access error case, don't issue data_req but send error response back to WB stage
-          data_req_o   = 1'b0;          
+          data_req_o   = 1'b0;
           cheri_err_d  = 1'b1;
           ctrl_update  = 1'b1;         // update ctrl/address so we can report error correctly
           addr_update  = 1'b1;
@@ -456,7 +456,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
           end else begin
             ls_fsm_ns           = CTX_WAIT_GNT1;
           end
-        end else if ((lsu_req_i | tbre_req_good) & ~resp_wait) begin   
+        end else if ((lsu_req_i | tbre_req_good) & ~resp_wait) begin
           // normal data access case
           data_req_o   = 1'b1;
           cheri_err_d  = 1'b0;
@@ -579,7 +579,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
         end
       end
 
-      CTX_WAIT_RESP: begin        // only needed if mem allows 2 active req 
+      CTX_WAIT_RESP: begin        // only needed if mem allows 2 active req
         if (cheri_pmode_i) begin
           addr_incr_req_o = 1'b1; // stay 1 to reduce unnecessary addr toggling
           data_req_o      = 1'b0;
@@ -614,7 +614,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
 
   assign resp_wait = CHERIoTEn & cheri_pmode_i & CheriTBRE & outstanding_resp_q & ~lsu_resp_valid;
 
-  // we assume ctrl will be held till req_done asserted 
+  // we assume ctrl will be held till req_done asserted
   // (once req captured in IDLE, it can be deasserted)
   logic lsu_req_done;
 
@@ -624,7 +624,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
   assign lsu_req_done_intl_o = lsu_req_done & (lsu_is_intl_i)  & (~cur_req_is_tbre) & cheri_pmode_i;
   assign lsu_tbre_req_done_o = lsu_req_done & cur_req_is_tbre & cheri_pmode_i;
 
-  assign cur_req_is_tbre = CHERIoTEn & cheri_pmode_i & CheriTBRE & ((ls_fsm_cs == IDLE) ? 
+  assign cur_req_is_tbre = CHERIoTEn & cheri_pmode_i & CheriTBRE & ((ls_fsm_cs == IDLE) ?
                            (tbre_req_good & ~resp_wait) : req_is_tbre_q);
 
   // registers for FSM
@@ -685,7 +685,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
   // Outputs //
   /////////////
   logic all_resp;
-  assign data_or_pmp_err    = lsu_err_q | data_err_i | pmp_err_q | (cheri_pmode_i & 
+  assign data_or_pmp_err    = lsu_err_q | data_err_i | pmp_err_q | (cheri_pmode_i &
                               (cheri_err_q | (resp_is_cap_q & cap_lsw_err_q)));
 
   assign all_resp           = data_rvalid_i | pmp_err_q | (cheri_pmode_i & cheri_err_q);
@@ -697,7 +697,7 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
   assign lsu_resp_is_wr_o        = data_we_q;
 
   // this goes to wb as rf_we_lsu, so needs to be gated when data needs to go back to EX
-  assign lsu_rdata_valid_o  = (ls_fsm_cs == IDLE) & data_rvalid_i & ~data_or_pmp_err & ~data_we_q & 
+  assign lsu_rdata_valid_o  = (ls_fsm_cs == IDLE) & data_rvalid_i & ~data_or_pmp_err & ~data_we_q &
                               (~cheri_pmode_i | ((~resp_is_intl_q) & (~resp_is_tbre_q)));
 
   // output to register file
@@ -713,8 +713,8 @@ module ibex_load_store_unit import ibex_pkg::*; import cheri_pkg::*; #(
     assign lsu_rdata_o = data_rdata_ext;
     assign lsu_rcap_o  = NULL_REG_CAP;
   end
-  
-  
+
+
   assign lsu_tbre_raw_lsw_o = cap_lsw_q;          // "raw" memory word to tbre
   assign lsu_tbre_sel_o = cur_req_is_tbre;        // req ctrl signal mux select (to cheri_ex)
 

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -55,7 +55,7 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   input  logic [31:0]                  boot_addr_i,
   input  logic                         cheri_pmode_i,
   input  logic                         cheri_tsafe_en_i,
- 
+
   input  logic                         instr_req_i,
   input  logic                         instr_gnt_i,
   input  logic                         instr_rvalid_i,
@@ -85,7 +85,7 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   input  logic [RegFileDataWidth-1:0]  rf_wdata_wb_ecc_i,
   input  logic [RegFileDataWidth-1:0]  rf_rdata_a_ecc_i,
   input  logic [RegFileDataWidth-1:0]  rf_rdata_b_ecc_i,
- 
+
   input  reg_cap_t                     rf_wcap_wb_i,
   input  reg_cap_t                     rf_rcap_a_i,
   input  reg_cap_t                     rf_rcap_b_i,
@@ -103,7 +103,7 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   input  logic [6:0]                   tsmap_rdata_intg_i,
   input  logic [MMRegDinW-1:0]         mmreg_corein_i,
   input  logic [MMRegDoutW-1:0]        mmreg_coreout_i,
- 
+
   input  logic [IC_NUM_WAYS-1:0]       ic_tag_req_i,
   input  logic                         ic_tag_write_i,
   input  logic [IC_INDEX_W-1:0]        ic_tag_addr_i,
@@ -315,10 +315,10 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   );
 
   if (CHERIoTEn) begin
-    assign rdata_tmp = shadow_inputs_q[LockstepOffset-1].data_rdata[31:0] ^ 
+    assign rdata_tmp = shadow_inputs_q[LockstepOffset-1].data_rdata[31:0] ^
                        {31'h0, shadow_inputs_q[LockstepOffset-1].data_rdata[32]};
   end else begin
-    assign rdata_tmp = shadow_inputs_q[LockstepOffset-1].data_rdata[31:0]; 
+    assign rdata_tmp = shadow_inputs_q[LockstepOffset-1].data_rdata[31:0];
   end
 
   prim_secded_inv_39_32_dec u_data_intg_dec (
@@ -347,7 +347,7 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
     );
   end
 
-  
+
   ////////////////////////////////////////
   // TSMAP interface integrity checking //
   ////////////////////////////////////////
@@ -466,8 +466,8 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   assign core_outputs_in.rf_trvk_par         = rf_trvk_par_i;
   assign core_outputs_in.tsmap_cs            = tsmap_cs_i;
   assign core_outputs_in.tsmap_addr          = tsmap_addr_i;
-  assign core_outputs_in.mmreg_coreout       = mmreg_coreout_i;     
-                        
+  assign core_outputs_in.mmreg_coreout       = mmreg_coreout_i;
+
   // Delay the outputs
   always_ff @(posedge clk_i) begin
     for (int unsigned i = 0; i < OutputsOffset - 1; i++) begin
@@ -559,18 +559,18 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
     .rf_rcap_a_i         (shadow_inputs_q[0].rf_rcap_a),
     .rf_rcap_b_i         (shadow_inputs_q[0].rf_rcap_b),
     .rf_reg_rdy_i        (shadow_inputs_q[0].rf_reg_rdy),
-    .rf_trsv_en_o        (shadow_outputs_d.rf_trsv_en),  
+    .rf_trsv_en_o        (shadow_outputs_d.rf_trsv_en),
     .rf_trsv_addr_o      (shadow_outputs_d.rf_trsv_addr),
     .rf_trsv_par_o       (shadow_outputs_d.rf_trsv_par),
     .rf_trvk_addr_o      (shadow_outputs_d.rf_trvk_addr),
-    .rf_trvk_en_o        (shadow_outputs_d.rf_trvk_en),  
+    .rf_trvk_en_o        (shadow_outputs_d.rf_trvk_en),
     .rf_trvk_clrtag_o    (shadow_outputs_d.rf_trvk_clrtag),
     .rf_trvk_par_o       (shadow_outputs_d.rf_trvk_par),
-    .tsmap_cs_o          (shadow_outputs_d.tsmap_cs),    
-    .tsmap_addr_o        (shadow_outputs_d.tsmap_addr), 
+    .tsmap_cs_o          (shadow_outputs_d.tsmap_cs),
+    .tsmap_addr_o        (shadow_outputs_d.tsmap_addr),
     .tsmap_rdata_i       (shadow_inputs_q[0].tsmap_rdata),
     .mmreg_corein_i      (shadow_inputs_q[0].mmreg_corein),
-    .mmreg_coreout_o     (shadow_outputs_d.mmreg_coreout),  
+    .mmreg_coreout_o     (shadow_outputs_d.mmreg_coreout),
 
     .ic_tag_req_o        (shadow_outputs_d.ic_tag_req),
     .ic_tag_write_o      (shadow_outputs_d.ic_tag_write),

--- a/rtl/ibex_top.sv
+++ b/rtl/ibex_top.sv
@@ -811,7 +811,7 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
     logic                         cheri_pmode_local;
     logic                         cheri_tsafe_en_local;
     logic [37:0]                  rf_wcap_vec_local;
-    logic [37:0]                  rf_rcap_a_vec_local; 
+    logic [37:0]                  rf_rcap_a_vec_local;
     logic [37:0]                  rf_rcap_b_vec_local;
     logic [31:0]                  rf_reg_rdy_local;
     logic                         rf_trsv_en_local;
@@ -1116,7 +1116,7 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
       .tsmap_rdata_i          (tsmap_rdata_local    ),
       .tsmap_rdata_intg_i     (tsmap_rdata_intg_local),
       .mmreg_corein_i         (mmreg_corein_local  ),
-      .mmreg_coreout_i        (mmreg_coreout_local      ), 
+      .mmreg_coreout_i        (mmreg_coreout_local      ),
 
       .ic_tag_req_i           (ic_tag_req_local),
       .ic_tag_write_i         (ic_tag_write_local),

--- a/rtl/ibex_tracer.sv
+++ b/rtl/ibex_tracer.sv
@@ -186,7 +186,7 @@ module ibex_tracer import cheri_pkg::*; # (
     if ((data_accessed & MEM) != 0) begin
       $fwrite(file_handle, " PA:0x%08x", rvfi_mem_addr);
 
-      if (rvfi_mem_wmask == 4'b0001)                           
+      if (rvfi_mem_wmask == 4'b0001)
         $fwrite(file_handle, " store:0x%1b??????%02x", rvfi_mem_wdata_bit32, rvfi_mem_wdata[7:0]);
       else if (rvfi_mem_wmask == 4'b0011)
         $fwrite(file_handle, " store:0x%1b????%04x", rvfi_mem_wdata_bit32, rvfi_mem_wdata[15:0]);
@@ -194,13 +194,13 @@ module ibex_tracer import cheri_pkg::*; # (
         $fwrite(file_handle, " store:0x%09x", rvfi_mem_wdata);
 
       if (rvfi_mem_rmask != 4'b0000)
-        $fwrite(file_handle, " load:0x%08x", rvfi_mem_rdata);  
+        $fwrite(file_handle, " load:0x%08x", rvfi_mem_rdata);
     end
 
     if ((data_accessed & MEMC) != 0) begin
       $fwrite(file_handle, " PA:0x%08x", rvfi_mem_addr);
 
-      if (rvfi_mem_wmask != 0)        
+      if (rvfi_mem_wmask != 0)
         $fwrite(file_handle, " store:0x%09x+0x%09x", rvfi_mem_wdata, reg2memcap_fmt0(rvfi_mem_wcap));
        else
         $fwrite(file_handle, " load:0x%09x+0x%09x", rvfi_mem_rdata, reg2memcap_fmt0(rvfi_mem_rcap));

--- a/rtl/ibexc_top.sv
+++ b/rtl/ibexc_top.sv
@@ -383,7 +383,7 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
     .ic_tag_rdata_i     (),
     .ic_tag_wdata_o     (),
     .ic_tag_addr_o      (),
-    .ic_tag_write_o     (), 
+    .ic_tag_write_o     (),
     .ic_tag_req_o       ()
   );
 

--- a/shared/sim_shared.core
+++ b/shared/sim_shared.core
@@ -22,4 +22,3 @@ targets:
   default:
     filesets:
       - files_sim_sv
-

--- a/syn/README.md
+++ b/syn/README.md
@@ -142,4 +142,3 @@ To open the design in OpenSTA
 $ sta
 % source ./tcl/sta_open_design.tcl
 ```
-


### PR DESCRIPTION
This PR removes trailing whitespace from SystemVerilog, markdown and core files that are not in the vendor directory.