### PR TITLE
Further Verilator lint fixes

### DIFF
--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -318,7 +318,7 @@ module cheri_ex import cheri_pkg::*; #(
     unique case (1'b1)
       cheri_operator_i[CGET_PERM]:
         begin
-          result_data_o       = rf_fullcap_a.perms;
+          result_data_o       = {19'h0, rf_fullcap_a.perms};
           result_cap_o        = NULL_REG_CAP;   // zerout the cap msw
           cheri_rf_we_raw     = 1'b1;
           cheri_ex_valid_raw  = 1'b1;
@@ -339,7 +339,7 @@ module cheri_ex import cheri_pkg::*; #(
         end
       cheri_operator_i[CGET_TOP]:
         begin
-          result_data_o       = rf_fullcap_a.top33[32]? 32'hffff_ffff : rf_fullcap_a.top33;
+          result_data_o       = rf_fullcap_a.top33[32] ? 32'hffff_ffff : rf_fullcap_a.top33[31:0];
           result_cap_o        = NULL_REG_CAP;
           cheri_rf_we_raw     = 1'b1;
           cheri_ex_valid_raw  = 1'b1;
@@ -353,7 +353,7 @@ module cheri_ex import cheri_pkg::*; #(
         end
       cheri_operator_i[CGET_TAG]:
         begin
-          result_data_o       = rf_fullcap_a.valid;
+          result_data_o       = {31'h0, rf_fullcap_a.valid};
           result_cap_o        = NULL_REG_CAP;
           cheri_rf_we_raw     = 1'b1;
           cheri_ex_valid_raw  = 1'b1;
@@ -370,7 +370,7 @@ module cheri_ex import cheri_pkg::*; #(
           result_data_o        = rf_rdata_a;
 
           if (cheri_operator_i[CSEAL])
-            result_cap_o       = full2regcap(seal_cap(rf_fullcap_a, rf_rdata_b[3:0]));
+            result_cap_o       = full2regcap(seal_cap(rf_fullcap_a, rf_rdata_b[OTYPE_W-1:0]));
           else begin
             tfcap                = unseal_cap(rf_fullcap_a);
             tfcap.perms[PERM_GL] = rf_fullcap_a.perms[PERM_GL] & rf_fullcap_b.perms[PERM_GL];
@@ -386,7 +386,7 @@ module cheri_ex import cheri_pkg::*; #(
         begin
           result_data_o      = rf_rdata_a;
           tfcap              = rf_fullcap_a;
-          tfcap.perms        = tfcap.perms & rf_rdata_b;
+          tfcap.perms        = tfcap.perms & rf_rdata_b[PERMS_W-1:0];
           tfcap.cperms       = compress_perms(tfcap.perms, tfcap.cperms[5:4]);
           tfcap.valid        = tfcap.valid & ~is_cap_sealed(rf_fullcap_a);
           result_cap_o       = full2regcap(tfcap);
@@ -451,15 +451,15 @@ module cheri_ex import cheri_pkg::*; #(
         end
       cheri_operator_i[CIS_SUBSET]:      // rd <-- (cs1.tag == cs2.tag) && (cs2 is_subset_of cs1)
         begin
-          result_data_o       = (rf_fullcap_a.valid  == rf_fullcap_b.valid) &&
-                                 ~addr_bound_vio && (&(rf_fullcap_a.perms | ~rf_fullcap_b.perms));
+          result_data_o       = 32'((rf_fullcap_a.valid  == rf_fullcap_b.valid) &&
+                                 ~addr_bound_vio && (&(rf_fullcap_a.perms | ~rf_fullcap_b.perms)));
           result_cap_o        = NULL_REG_CAP;
           cheri_rf_we_raw     = 1'b1;
           cheri_ex_valid_raw  = 1'b1;
         end
       cheri_operator_i[CIS_EQUAL]:       // rd <-- (cs1 == cs2)
         begin
-          result_data_o       = is_equal(rf_fullcap_a, rf_fullcap_b, rf_rdata_a, rf_rdata_b);
+          result_data_o       = 32'(is_equal(rf_fullcap_a, rf_fullcap_b, rf_rdata_a, rf_rdata_b));
           result_cap_o        = NULL_REG_CAP;
           cheri_rf_we_raw     = 1'b1;
           cheri_ex_valid_raw  = 1'b1;
@@ -625,7 +625,7 @@ module cheri_ex import cheri_pkg::*; #(
   end
 
   assign cheri_lsu_we       = is_intl ? 1'b0 : is_store_cap;
-  assign cheri_lsu_addr     = (is_intl ? intl_lsu_addr : cs1_addr_plusimm) + {addr_incr_req_i, 2'b00};
+  assign cheri_lsu_addr     = (is_intl ? intl_lsu_addr : cs1_addr_plusimm) + {29'h0, addr_incr_req_i, 2'b00};
   assign cheri_lsu_is_cap   = is_intl ? intl_lsu_is_cap : is_cap;
   assign cheri_lsu_is_intl  = is_intl;
 
@@ -719,7 +719,7 @@ module cheri_ex import cheri_pkg::*; #(
       tfcap3 = rf_fullcap_a;
       tmp_addr  = rf_rdata_a;
     end else if (cheri_operator_i[CSET_BOUNDS_IMM]) begin
-      newlen    = cheri_imm12_i;  // unsigned imm
+      newlen    = 32'(cheri_imm12_i);  // unsigned imm
       req_exact = 1'b0;
       tfcap3 = rf_fullcap_a;
       tmp_addr  = rf_rdata_a;
@@ -780,9 +780,9 @@ module cheri_ex import cheri_pkg::*; #(
   always_comb begin : check_rv32
     logic [31:0] top_offset;
     logic [32:0] top_bound;
-    logic [31:0] base_bound;
+    logic [31:0] base_bound, base_chkaddr;
     logic        top_vio, base_vio;
-    logic [32:0] top_chkaddr, base_chkaddr;
+    logic [32:0] top_chkaddr;
     logic        top_size_ok;
 
     // generate the address used to check top bound violation
@@ -800,7 +800,7 @@ module cheri_ex import cheri_pkg::*; #(
     end
 
     //top_chkaddr = base_chkaddr + top_offset;
-    top_chkaddr = base_chkaddr;
+    top_chkaddr = {1'b0, base_chkaddr};
 
     // top_bound  = rf_fullcap_a.top33;
     top_bound  = rf_fullcap_a.top33 - top_offset;
@@ -839,8 +839,8 @@ module cheri_ex import cheri_pkg::*; #(
   always_comb begin : check_cheri
     logic [31:0] top_offset;
     logic [32:0] top_bound;
-    logic [31:0] base_bound;
-    logic [32:0] top_chkaddr, base_chkaddr;
+    logic [31:0] base_bound, base_chkaddr;
+    logic [32:0] top_chkaddr;
     logic        top_vio, base_vio, top_equal;
     logic        cs2_bad_type;
 
@@ -855,9 +855,9 @@ module cheri_ex import cheri_pkg::*; #(
     if (cheri_operator_i[CIS_SUBSET])
       top_chkaddr = rf_fullcap_b.top33;
     else if (is_cap)  // CLC/CSC
-      top_chkaddr = {base_chkaddr[31:3], 3'b000};
+      top_chkaddr = {1'b0, base_chkaddr[31:3], 3'b000};
     else 
-      top_chkaddr = base_chkaddr;
+      top_chkaddr = {1'b0, base_chkaddr};
 
     if (cheri_operator_i[CSEAL] | cheri_operator_i[CUNSEAL]) begin
       top_bound  = rf_fullcap_b.top33;
@@ -916,7 +916,7 @@ module cheri_ex import cheri_pkg::*; #(
     end else if (cheri_operator_i[CUNSEAL]) begin
       perm_vio_vec[PVIO_TAG]   = ~rf_fullcap_a.valid || ~rf_fullcap_b.valid; 
       perm_vio_vec[PVIO_SEAL]  = (~is_cap_sealed(rf_fullcap_a)) || is_cap_sealed(rf_fullcap_b) ||
-                                   (rf_rdata_b != decode_otype(rf_fullcap_a.otype, rf_fullcap_a.perms[PERM_EX])) ||
+                                   (rf_rdata_b != {28'h0, decode_otype(rf_fullcap_a.otype, rf_fullcap_a.perms[PERM_EX])}) ||
                                    (~rf_fullcap_b.perms[PERM_US]);
     end else if (cheri_operator_i[CJALR]) begin
       perm_vio_vec[PVIO_TAG]   = (~rf_fullcap_a.valid);
@@ -1234,29 +1234,29 @@ end
   // debug signal for FPGA only
   //
   logic [15:0] dbg_status;
-  logic [68:0] dbg_cs1_vec, dbg_cs2_vec, dbg_cd_vec;
+  logic [67:0] dbg_cs1_vec, dbg_cs2_vec, dbg_cd_vec;
 
   assign dbg_status = {4'h0,
                        instr_is_rv32lsu_i, rv32_lsu_req_i, rv32_lsu_we_i,  rv32_lsu_err,
                        cheri_exec_id_i, cheri_lsu_err, rf_fullcap_a.valid, result_cap_o.valid,
                        addr_bound_vio, perm_vio, addr_bound_vio_rv32, perm_vio_rv32};
 
-  assign dbg_cs1_vec = {rf_fullcap_a.top_cor, rf_fullcap_a.base_cor, // 68:65
-                        rf_fullcap_a.exp,                            // 64:60
-                        rf_fullcap_a.top, rf_fullcap_a.base,         // 59:42
-                        rf_fullcap_a.otype, rf_fullcap_a.cperms,     // 41:32
+  assign dbg_cs1_vec = {rf_fullcap_a.top_cor, rf_fullcap_a.base_cor, // 67:64
+                        rf_fullcap_a.exp,                            // 63:59
+                        rf_fullcap_a.top, rf_fullcap_a.base,         // 58:41
+                        rf_fullcap_a.otype, rf_fullcap_a.cperms,     // 40:32
                         rf_rdata_a};                                 // 31:0
 
-  assign dbg_cs2_vec = {rf_fullcap_b.top_cor, rf_fullcap_b.base_cor, // 68:65
-                        rf_fullcap_b.exp,                            // 64:60
-                        rf_fullcap_b.top, rf_fullcap_b.base,         // 59:42
-                        rf_fullcap_b.otype, rf_fullcap_b.cperms,     // 41:32
+  assign dbg_cs2_vec = {rf_fullcap_b.top_cor, rf_fullcap_b.base_cor, // 67:64
+                        rf_fullcap_b.exp,                            // 63:59
+                        rf_fullcap_b.top, rf_fullcap_b.base,         // 58:41
+                        rf_fullcap_b.otype, rf_fullcap_b.cperms,     // 40:32
                         rf_rdata_b};                                 // 31:0
 
-  assign dbg_cd_vec = {result_cap_o.top_cor, result_cap_o.base_cor,  // 68:65
-                        result_cap_o.exp,                            // 64:60
-                        result_cap_o.top, result_cap_o.base,         // 59:42
-                        result_cap_o.otype, result_cap_o.cperms,     // 41:32
+  assign dbg_cd_vec = {result_cap_o.top_cor, result_cap_o.base_cor,  // 67:64
+                        result_cap_o.exp,                            // 63:59
+                        result_cap_o.top, result_cap_o.base,         // 58:41
+                        result_cap_o.otype, result_cap_o.cperms,     // 40:32
                         result_data_o};                              // 31:0
 
 

--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -184,14 +184,14 @@ module cheri_ex import cheri_pkg::*; #(
   logic  [31:0]  addr_result;
 
   logic          intl_lsu_req;
-  logic          intl_lsu_we;
+  logic          unused_intl_lsu_we;
   logic [31:0]   intl_lsu_addr;
   logic [32:0]   intl_lsu_wdata;
   reg_cap_t      intl_lsu_wcap;
   logic          intl_lsu_is_cap;
 
   logic          clbc_done;
-  logic          clbc_err, clbc_err_q;
+  logic          clbc_err;
   logic  [31:0]  clbc_data_q;
   reg_cap_t      clbc_cap_q;
   logic          clbc_revoked;
@@ -1026,9 +1026,10 @@ module cheri_ex import cheri_pkg::*; #(
     logic  [4:0] ts_map_bitpos;    // bit index in a 32-bit word
     logic        clbc_map_ok;
     logic [31:0] clbc_map_q;
+    logic        clbc_err_q;
 
     assign clbc_revoked    = clbc_map_ok && clbc_map_q[ts_map_bitpos] & cheri_tsafe_en_i;
-    assign intl_lsu_we    = 1'b0;
+    assign unused_intl_lsu_we    = 1'b0;
     assign intl_lsu_wdata = 33'h0;
     assign intl_lsu_wcap  = NULL_REG_CAP;
 
@@ -1111,7 +1112,7 @@ module cheri_ex import cheri_pkg::*; #(
     assign intl_lsu_req    = 1'b0;
     assign intl_lsu_is_cap = 1'b0;
     assign intl_lsu_addr   = 32'h0;
-    assign intl_lsu_we     = 1'b0;
+    assign unused_intl_lsu_we = 1'b0;
     assign intl_lsu_wdata  = 33'h0;
     assign intl_lsu_wcap   = NULL_REG_CAP;
   end

--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -1115,6 +1115,14 @@ module cheri_ex import cheri_pkg::*; #(
     assign unused_intl_lsu_we = 1'b0;
     assign intl_lsu_wdata  = 33'h0;
     assign intl_lsu_wcap   = NULL_REG_CAP;
+    assign clbc_done = 1'b0;
+    assign clbc_err = 1'b0;
+    assign clbc_revoked = 1'b1;
+
+    always_ff @(posedge clk_i) begin
+      clbc_data_q <= 32'h0;
+      clbc_cap_q <= NULL_REG_CAP;
+    end
   end
 
   //

--- a/rtl/cheri_pkg.sv
+++ b/rtl/cheri_pkg.sv
@@ -330,7 +330,7 @@ package cheri_pkg;
   endfunction
 
 
-  // utillity function
+  // utility function
   // return the size (bit length) of input number without leading zeros
   function automatic logic [5:0] get_size(logic [31:0] din);
     logic  [5:0] count;

--- a/rtl/cheri_pkg.sv
+++ b/rtl/cheri_pkg.sv
@@ -153,7 +153,7 @@ package cheri_pkg;
   `define TEST_IMSK(P, M) (&((P) | ~(M)))
 
   // compress perms field to memory representation
-  function automatic logic [CPERMS_W-1:0] compress_perms (logic [PERMS_W-1:0] perms, logic [1:0] qqq);   // qqq is a place holder, just to compatible with the old encoding for now.
+  function automatic logic [CPERMS_W-1:0] compress_perms (logic [PERMS_W-1:0] perms, logic [1:0] unused_qqq);   // unused_qqq is a place holder, just to compatible with the old encoding for now.
     logic [CPERMS_W-1:0] cperms;
 
     // test all types encoding and determine encoding (Robert's priority order)

--- a/rtl/cheri_regfile.sv
+++ b/rtl/cheri_regfile.sv
@@ -121,8 +121,8 @@ module cheri_regfile import cheri_pkg::*; #(
     assign rf_reg_par[i] = rf_reg_par_q[i];     
   end
 
-  assign rdata_a_o = {rf_reg_par[raddr_a_i], rf_reg[raddr_a_i]};
-  assign rdata_b_o = {rf_reg_par[raddr_b_i], rf_reg[raddr_b_i]};
+  assign rdata_a_o = DataWidth'({rf_reg_par[raddr_a_i], rf_reg[raddr_a_i]});
+  assign rdata_b_o = DataWidth'({rf_reg_par[raddr_b_i], rf_reg[raddr_b_i]});
 
   // capability meta data (MSW)
   for (genvar i = 1; i < NCAPS; i++) begin : g_cap_flops

--- a/rtl/cheri_regfile.sv
+++ b/rtl/cheri_regfile.sv
@@ -80,7 +80,6 @@ module cheri_regfile import cheri_pkg::*; #(
 
   // No flops for R0 as it's hard-wired to 0
   for (genvar i = 1; i < NREGS; i++) begin : g_rf_flops
-    logic cap_valid;
     
     
     always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/rtl/cheri_tbre_wrapper.sv
+++ b/rtl/cheri_tbre_wrapper.sv
@@ -82,7 +82,7 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
 
   logic          tbre_stat, tbre_err, stkz_err;
 
-  assign mmreg_coreout_o = {{(MMRegDoutW-8){1'b0}}, 2'b00, 2'b00, stkz_err, stkz_active_o,
+  assign mmreg_coreout_o = {{(MMRegDoutW-10){1'b0}}, 2'b00, 2'b00, stkz_err, stkz_active_o,
                                                     2'b00,  tbre_err, tbre_stat};
 
   if (CHERIoTEn & CheriTBRE) begin : g_tbre
@@ -190,7 +190,7 @@ module cheri_tbre_wrapper import cheri_pkg::*; #(
   for (genvar i = 0; i < nMSTR; i++) begin
     logic [7:0] pri_mask;
     assign pri_mask = 8'hff >> (8-i);      // max 8 masters, should be enough 
-    assign mstr_arbit[i] = mstr_req[i] & ~(|(mstr_req & pri_mask));
+    assign mstr_arbit[i] = mstr_req[i] & ~(|(mstr_req & pri_mask[nMSTR-1:0]));
   end
 
   // Handling delayed-gnt case. 

--- a/rtl/cheri_trvk_stage.sv
+++ b/rtl/cheri_trvk_stage.sv
@@ -50,12 +50,12 @@ module cheri_trvk_stage #(
 
   logic [31:0] base32;
   logic [31:0] tsmap_ptr;
-  logic  [4:0] bitpos, bitpos_q;    // bit index in a 32-bit word
+  logic  [4:0] bitpos_q; // bit index in a 32-bit word
   logic        range_ok;
   logic  [2:1] range_ok_q;
 
 
-  assign base32    = get_bound33(in_cap_q.base, in_cap_q.base_cor, in_cap_q.exp, in_data_q);
+  assign base32    = 32'(get_bound33(in_cap_q.base, in_cap_q.base_cor, in_cap_q.exp, in_data_q));
   assign tsmap_ptr = (base32 - HeapBase) >> 3;
 
   assign tsmap_addr_o  = tsmap_ptr[15:5];
@@ -75,7 +75,7 @@ module cheri_trvk_stage #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       cpu_op_active <= 1'b0;
-      trsv_addr  <= 4'h0;
+      trsv_addr  <= 5'h0;
     end else begin
       if (rf_trsv_en_i) cpu_op_active <= 1'b1;
       else if (lsu_resp_valid_i) cpu_op_active <= 1'b0;

--- a/rtl/cheri_trvk_stage.sv
+++ b/rtl/cheri_trvk_stage.sv
@@ -91,7 +91,6 @@ module cheri_trvk_stage #(
                           (lsu_tbre_resp_valid_i & ~lsu_tbre_resp_err_i &  rf_wcap_lsu_i.valid);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    int i;
     if (!rst_ni) begin
       cpu_op_valid_q  <= 0;
       tbre_op_valid_q <= 0;

--- a/rtl/ibex_controller.sv
+++ b/rtl/ibex_controller.sv
@@ -780,7 +780,7 @@ module ibex_controller #(
                   csr_mtval_o = lsu_addr_last_i;
                 end else begin
                   exc_cause_o = EXC_CAUSE_CHERI_FAULT; 
-                  csr_mtval_o = cheri_wb_err_info_i[10:0];
+                  csr_mtval_o = {21'h0, cheri_wb_err_info_i[10:0]};
                 end
               end else begin
                 exc_cause_o = EXC_CAUSE_STORE_ACCESS_FAULT;
@@ -794,7 +794,7 @@ module ibex_controller #(
                   csr_mtval_o = lsu_addr_last_i;
                 end else begin
                   exc_cause_o = EXC_CAUSE_CHERI_FAULT;
-                  csr_mtval_o = cheri_wb_err_info_i[10:0];
+                  csr_mtval_o = {21'h0, cheri_wb_err_info_i[10:0]};
                 end
               end else begin
                 exc_cause_o = EXC_CAUSE_LOAD_ACCESS_FAULT;
@@ -804,17 +804,17 @@ module ibex_controller #(
             cheri_ex_err_prio: begin
               if (cheri_pmode_i) begin
                 exc_cause_o = EXC_CAUSE_CHERI_FAULT;
-                csr_mtval_o = cheri_ex_err_info_i[10:0];        
+                csr_mtval_o = {21'h0, cheri_ex_err_info_i[10:0]};
               end
             end
             cheri_wb_err_prio: begin
               if (cheri_pmode_i) begin
                 if (cheri_wb_err_info_i[12]) begin  // illegal SCR addr 
                   exc_cause_o = EXC_CAUSE_ILLEGAL_INSN;
-                  csr_mtval_o = cheri_wb_err_info_i[10:0];
+                  csr_mtval_o = {21'h0, cheri_wb_err_info_i[10:0]};
                 end else begin
                   exc_cause_o = EXC_CAUSE_CHERI_FAULT;
-                  csr_mtval_o = cheri_wb_err_info_i[10:0];
+                  csr_mtval_o = {21'h0, cheri_wb_err_info_i[10:0]};
                 end
               end
             end

--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -173,7 +173,7 @@ module ibex_cs_registers import cheri_pkg::*;  #(
     | (0                 << 13)  // N - User level interrupts supported
     | (0                 << 18)  // S - Supervisor mode implemented
     | (1                 << 20)  // U - User mode implemented
-    | (CHERIoTEn         << 23)  // X - Non-standard extensions present
+    | (32'(CHERIoTEn)    << 23)  // X - Non-standard extensions present
     | (32'(CSR_MISA_MXL) << 30); // M-XLEN
 
   typedef struct packed {

--- a/rtl/ibex_id_stage.sv
+++ b/rtl/ibex_id_stage.sv
@@ -230,7 +230,7 @@ module ibex_id_stage import cheri_pkg::*; #(
   logic        wfi_insn_dec;
 
   logic        wb_exception;
-  logic        id_exception;
+  logic        unused_id_exception;
   logic        id_exception_nc;
 
   logic        branch_in_dec;
@@ -655,7 +655,7 @@ module ibex_id_stage import cheri_pkg::*; #(
     .store_err_i    (lsu_store_err_i),
     .lsu_err_is_cheri_i (lsu_err_is_cheri_i),
     .wb_exception_o (wb_exception),
-    .id_exception_o (id_exception),
+    .id_exception_o (unused_id_exception),
     .id_exception_nc_o (id_exception_nc),
 
     // jump/branch control
@@ -1170,7 +1170,6 @@ module ibex_id_stage import cheri_pkg::*; #(
     logic unused_outstanding_store_wb;
     logic unused_wb_exception;
     logic [31:0] unused_rf_wdata_fwd_wb;
-    logic unused_id_exception;
 
     assign unused_data_req_done_ex     = lsu_req_done_i;
     assign unused_rf_waddr_wb          = rf_waddr_wb_i;
@@ -1179,7 +1178,6 @@ module ibex_id_stage import cheri_pkg::*; #(
     assign unused_outstanding_store_wb = outstanding_store_wb_i;
     assign unused_wb_exception         = wb_exception;
     assign unused_rf_wdata_fwd_wb      = rf_wdata_fwd_wb_i;
-    assign unused_id_exception         = id_exception;
 
     assign instr_type_wb_o = WB_INSTR_OTHER;
     assign stall_wb        = 1'b0;

--- a/rtl/ibex_if_stage.sv
+++ b/rtl/ibex_if_stage.sv
@@ -355,11 +355,11 @@ module ibex_if_stage import ibex_pkg::*; import cheri_pkg::*; #(
 
   // let's only check this in pure-cap mode. otherwise jalr/ret gives so much headache
   // pre-calculate headroom to improve memory read timing
-  logic [2:0]  instr_len;
+  logic [2:0]  unused_instr_len;
   logic [32:0] instr_hdrm;
   logic        hdrm_ge4, hdrm_ge2, hdrm_ok;
 
-  assign instr_len  = (fetch_valid & ~fetch_err & instr_is_compressed) ? 2 : 4;
+  assign unused_instr_len  = (fetch_valid & ~fetch_err & instr_is_compressed) ? 2 : 4;
   assign instr_hdrm = pcc_cap_i.top33 - if_instr_addr;
   assign hdrm_ge4   = (instr_hdrm >= 4);
   assign hdrm_ge2   = (instr_hdrm >= 2);

--- a/rtl/ibexc_top.sv
+++ b/rtl/ibexc_top.sv
@@ -372,8 +372,8 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
 `endif
 
     .fetch_enable_i(fetch_enable_buf),
-    .alert_minor_o(),
-    .alert_major_o(),
+    .alert_minor_o(alert_minor_o),
+    .alert_major_o(alert_major_internal_o),
     .icache_inval_o(),
     .core_busy_o   (core_busy_d),
     .ic_scr_key_valid_i (1'b0),
@@ -390,6 +390,7 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
   );
 
   assign data_wdata_intg_o = 7'h0;
+  assign alert_major_bus_o = 1'b0;
 
   /////////////////////////////////
   // Register file Instantiation //
@@ -453,5 +454,7 @@ module ibex_top import ibex_pkg::*; import cheri_pkg::*; #(
       .alert_o       ()
     );
   end
+
+  assign scramble_req_o = 0;
 
 endmodule


### PR DESCRIPTION
Found these issues while compiling CHERIoT Ibex with Verilator. It mainly fixes width mismatches and unused variables.

This PR does not remove all unused variables, there is one remaining width issue and two unoptimized flat issues.