### PR TITLE
Optional Tracing

### DIFF
--- a/ibex_top_tracing.core
+++ b/ibex_top_tracing.core
@@ -18,7 +18,6 @@ parameters:
   RVFI:
     datatype: bool
     paramtype: vlogdefine
-    default: true
 
   SYNTHESIS:
     datatype: bool
@@ -111,8 +110,6 @@ targets:
   default: &default_target
     filesets:
       - files_rtl
-    parameters:
-      - RVFI=true
     toplevel: ibex_top_tracing
 
   lint:

--- a/rtl/ibexc_top_tracing.sv
+++ b/rtl/ibexc_top_tracing.sv
@@ -96,7 +96,7 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   input  logic                         scan_rst_ni
 );
 
-
+`ifdef RVFI
   logic        rvfi_valid;
   logic [63:0] rvfi_order;
   logic [31:0] rvfi_insn;
@@ -142,6 +142,7 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   assign unused_rvfi_ext_nmi = rvfi_ext_nmi;
   assign unused_rvfi_ext_debug_req = rvfi_ext_debug_req;
   assign unused_rvfi_ext_mcycle = rvfi_ext_mcycle;
+`endif
 
   ibex_top #(
     .DmHaltAddr       (DmHaltAddr       ),
@@ -265,10 +266,6 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
 
 // ibex_tracer relies on the signals from the RISC-V Formal Interface
 // synthesis translate_off
-`ifndef RVFI
-   $fatal("Fatal error: RVFI needs to be defined globally.");
-`endif
-
 `ifdef RVFI
   ibex_tracer #(
     .DataWidth        (DataWidth)

--- a/rtl/ibexc_top_tracing.sv
+++ b/rtl/ibexc_top_tracing.sv
@@ -13,6 +13,10 @@
 module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   parameter int unsigned DmHaltAddr       = 32'h1A110800,
   parameter int unsigned DmExceptionAddr  = 32'h1A110808,
+  parameter bit          DbgTriggerEn     = 1'b1,
+  parameter int unsigned DbgHwBreakNum    = 2,
+  parameter int unsigned MHPMCounterNum   = 0,
+  parameter rv32b_e      RV32B            = RV32BNone,
   parameter int unsigned HeapBase         = 32'h2001_0000,
   parameter int unsigned TSMapBase        = 32'h2004_0000, // 4kB default
   parameter int unsigned TSMapSize        = 1024,          // in words
@@ -25,7 +29,6 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   input  logic                         rst_ni,
 
   input  logic                         test_en_i,     // enable all clock gates for testing
-  input  logic                         scan_rst_ni,
   input  prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
   input  logic                         cheri_pmode_i,
@@ -60,7 +63,6 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   output logic                         tsmap_cs_o,
   output logic [15:0]                  tsmap_addr_o,
   input  logic [31:0]                  tsmap_rdata_i,
-  input  logic [6:0]                   tsmap_rdata_intg_i,   // not used in ibexc_top
   input  logic [MMRegDinW-1:0]         mmreg_corein_i,
   output logic [MMRegDoutW-1:0]        mmreg_coreout_o,
   output logic                         cheri_fatal_err_o,
@@ -85,7 +87,13 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
 
   // CPU Control Signals
   input  fetch_enable_t                fetch_enable_i,
-  output logic                         core_sleep_o
+  output logic                         core_sleep_o,
+  output logic                         alert_minor_o,
+  output logic                         alert_major_internal_o,
+  output logic                         alert_major_bus_o,
+
+  // DFT bypass controls
+  input  logic                         scan_rst_ni
 );
 
 
@@ -138,12 +146,12 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
   ibex_top #(
     .DmHaltAddr       (DmHaltAddr       ),
     .DmExceptionAddr  (DmExceptionAddr  ),
-    .MHPMCounterNum   (13  ),
+    .MHPMCounterNum   (MHPMCounterNum),
     .MHPMCounterWidth (40),
-    .DbgTriggerEn     (1'b1),
-    .DbgHwBreakNum    (4),
+    .DbgTriggerEn     (DbgTriggerEn),
+    .DbgHwBreakNum    (DbgHwBreakNum    ),
     .RV32E            (1'b0),
-    .RV32B            (RV32BFull),
+    .RV32B            (RV32B),
     .WritebackStage   (1'b1),
     .BranchPredictor  (1'b0),
     .CHERIoTEn        (1'b1),


### PR DESCRIPTION
I made these changes for the sonata system and thought they may be valuable upstream.

I've changes `ibexc_top_tracing` module to match ports and parameters of `ibexc_top`. I've also made it possible to leave `RVFI` unset, in which case `ibexc_top_tracing` is equivalent to `ibexc_top`.

This allows users to use `ibexc_top_tracing` as a drop in replacement for `ibexc_top`, with the tracing only enabled when `RVFI` is enabled so that the same system top can be used for simulation and synthesis.