### PR TITLE
Fix clearing fetch FIFO twice when CJALR fails

### DIFF
--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -599,7 +599,7 @@ module cheri_ex import cheri_pkg::*; #(
 
           cheri_rf_we_raw      = ~instr_fault;    // err -> wb exception
           branch_req_raw       = ~instr_fault & cheri_operator_i[CJALR];    // update PCC in CSR
-          branch_req_spec_raw  = 1'b1;
+          branch_req_spec_raw  = ~instr_fault;
 
           cheri_wb_err_raw     = instr_fault;
           cheri_ex_err_raw     = 1'b0;


### PR DESCRIPTION
When CJALR fails, for example on a permit execute violation, the fetch FIFO is cleared twice, first because `branch_req_spec_raw` is asserted in the `cheri_ex` module and second because `cheri_wb_err_o` is asserted the next cycle. This causes the first instruction of the trap handler to be cleared and causes the PC and instruction data to get out of sync.

The solution in this commit is to not assert `branch_req_spec_raw` when there is an instruction fault.

Closes: https://github.com/microsoft/cheriot-ibex/issues/28