### PR TITLE
Base correction only needs one bit

### DIFF
--- a/dv/cheriot/fcov/core_ibex_fcov_if.sv
+++ b/dv/cheriot/fcov/core_ibex_fcov_if.sv
@@ -859,14 +859,14 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; import cher
 
     cp_cs1_sealed: coverpoint ((g_cheri_ex.u_cheri_ex.rf_fullcap_a.otype != 0) & (g_cheri_ex.u_cheri_ex.rf_fullcap_a.valid));
 
-    cp_cs1_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_a.base_cor, 
+    cp_cs1_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_a.base_cor,
                             g_cheri_ex.u_cheri_ex.rf_fullcap_a.top_cor} {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
-      // bins bin2 = {4'b0011}; // base_cor = 0, top_cor = -1, impossible case
-      bins bin3 = {4'b1100}; 
-      // bins bin4 = {4'b1101};    // impossible case
-      bins bin5 = {4'b1111};
+      bins bin0 = {3'b000}; 
+      bins bin1 = {3'b001}; 
+      // bins bin2 = {3'b011}; // base_cor = 0, top_cor = -1, impossible case
+      bins bin3 = {3'b100}; 
+      // bins bin4 = {3'b101};    // impossible case
+      bins bin5 = {3'b111};
     }
 
     cp_cs1_top: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_a.top {
@@ -999,14 +999,14 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; import cher
 
     cp_cs2_sealed: coverpoint ((g_cheri_ex.u_cheri_ex.rf_fullcap_b.otype != 0) & (g_cheri_ex.u_cheri_ex.rf_fullcap_b.valid));
 
-    cp_cs2_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_b.base_cor, 
+    cp_cs2_cor: coverpoint {g_cheri_ex.u_cheri_ex.rf_fullcap_b.base_cor,
                             g_cheri_ex.u_cheri_ex.rf_fullcap_b.top_cor} {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
-      // bins bin2 = {4'b0011}; // base_cor = 0, top_cor = -1, impossible case
-      bins bin3 = {4'b1100}; 
-      // bins bin4 = {4'b1101};    // impossible case
-      bins bin5 = {4'b1111};    
+      bins bin0 = {3'b000};
+      bins bin1 = {3'b001};
+      // bins bin2 = {3'b011}; // base_cor = 0, top_cor = -1, impossible case
+      bins bin3 = {3'b100};
+      // bins bin4 = {3'b101}; // impossible case
+      bins bin5 = {3'b111};
     }
 
     cp_cs2_top: coverpoint g_cheri_ex.u_cheri_ex.rf_fullcap_b.top {
@@ -1080,14 +1080,14 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; import cher
       bins bin[] = {[0:7]};    // including reserved values for coverage
     }
 
-    cp_cd_cor: coverpoint {g_cheri_ex.u_cheri_ex.result_cap_o.base_cor, 
+    cp_cd_cor: coverpoint {g_cheri_ex.u_cheri_ex.result_cap_o.base_cor,
                            g_cheri_ex.u_cheri_ex.result_cap_o.top_cor} {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
-      // bins bin2 = {4'b0011}; 
-      bins bin3 = {4'b1100}; 
-      // bins bin4 = {4'b1101}; 
-      bins bin5 = {4'b1111}; 
+      bins bin0 = {3'b000};
+      bins bin1 = {3'b001};
+      // bins bin2 = {3'b011};
+      bins bin3 = {3'b100};
+      // bins bin4 = {3'b101};
+      bins bin5 = {3'b111};
     }
 
    cp_cd_top: coverpoint g_cheri_ex.u_cheri_ex.result_cap_o.top {
@@ -1253,15 +1253,15 @@ interface core_ibex_fcov_if import ibex_pkg::*; import cheri_pkg::*; import cher
       bins bin2 = {24};
     }
 
-    cp_clc_mem_cap_cor: coverpoint {load_store_unit_i.lsu_dv_ext_i.fcov_clc_mem_cap.top_cor,  
-                                    load_store_unit_i.lsu_dv_ext_i.fcov_clc_mem_cap.base_cor} iff
+    cp_clc_mem_cap_cor: coverpoint {load_store_unit_i.lsu_dv_ext_i.fcov_clc_mem_cap.base_cor,
+                                    load_store_unit_i.lsu_dv_ext_i.fcov_clc_mem_cap.top_cor} iff
                             (~load_store_unit_i.data_we_q & load_store_unit_i.lsu_resp_valid_o) {
-      bins bin0 = {4'b0000}; 
-      bins bin1 = {4'b0001}; 
-      // bins bin2 = {4'b0011}; // base_cor = 0, top_cor = -1, impossible case
-      bins bin3 = {4'b1100}; 
-      // bins bin4 = {4'b1101};    // impossible case
-      bins bin5 = {4'b1111};    
+      bins bin0 = {3'b000};
+      bins bin1 = {3'b001};
+      // bins bin2 = {3'b011}; // base_cor = 0, top_cor = -1, impossible case
+      bins bin3 = {3'b100};
+      // bins bin4 = {3'b101}; // impossible case
+      bins bin5 = {3'b111};
     }
 
     cp_cheri_fetch_tag_vio: coverpoint id_stage_i.instr_fetch_cheri_acc_vio_i iff

--- a/dv/cheriot/scripts/compare_trace.py
+++ b/dv/cheriot/scripts/compare_trace.py
@@ -125,7 +125,7 @@ def parse_ibex_cap(cap_val, addr_val):
         top_cor = -1;
 
     if addrmi9 < base9 :
-      base_cor = -1;
+      base_cor = 1;
     else :
       base_cor = 0;
 
@@ -134,7 +134,7 @@ def parse_ibex_cap(cap_val, addr_val):
       base = (base9 << exp);
     else:
       top  = (top9 << exp)  + (((addr_val >> (exp+9)) + top_cor)  << (exp+9));
-      base = (base9 << exp) + (((addr_val >> (exp+9)) + base_cor) << (exp+9));
+      base = (base9 << exp) + (((addr_val >> (exp+9)) - base_cor) << (exp+9));
 
     top  &= 0x1ffffffff    # convert to unsigned
     base &= 0xffffffff

--- a/dv/cheriot/tb/cheriot_dv_pkg.sv
+++ b/dv/cheriot/tb/cheriot_dv_pkg.sv
@@ -118,7 +118,7 @@ package cheriot_dv_pkg;
     full_cap_t result_cap;
 
     logic [EXP_W-1:0] tmp5;
-    logic [3:0]  tmp4;
+    logic [2:0]  tmp3;
     logic [CPERMS_W-1:0] cperms_mem;
     logic [BOT_W-1:0]    addrmi9;
     logic                valid_in;
@@ -137,9 +137,9 @@ package cheriot_dv_pkg;
     cperms_mem      = msw[CPERMS_LO+:CPERMS_W];
     regcap.cperms   = cperms_mem;
     addrmi9         = BOT_W'({1'b0, addr33[31:0]} >> regcap.exp); // ignore the tag valid bit
-    tmp4            = update_temp_fields(regcap.top, regcap.base, addrmi9);
-    regcap.top_cor  = tmp4[3:2];
-    regcap.base_cor = tmp4[1:0];
+    tmp3            = update_temp_fields(regcap.top, regcap.base, addrmi9);
+    regcap.top_cor  = tmp3[2:1];
+    regcap.base_cor = tmp3[0];
 
     regcap.rsvd     = msw[RSVD_LO];
 

--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -1127,26 +1127,26 @@ module cheri_ex import cheri_pkg::*; #(
   // debug signal for FPGA only
   //
   logic [15:0] dbg_status;
-  logic [67:0] dbg_cs1_vec, dbg_cs2_vec, dbg_cd_vec;
+  logic [66:0] dbg_cs1_vec, dbg_cs2_vec, dbg_cd_vec;
 
   assign dbg_status = {4'h0,
                        instr_is_rv32lsu_i, rv32_lsu_req_i, rv32_lsu_we_i,  rv32_lsu_err,
                        cheri_exec_id_i, cheri_lsu_err, rf_fullcap_a.valid, result_cap_o.valid,
                        addr_bound_vio, perm_vio, addr_bound_vio_rv32, perm_vio_rv32};
 
-  assign dbg_cs1_vec = {rf_fullcap_a.top_cor, rf_fullcap_a.base_cor, // 67:64
+  assign dbg_cs1_vec = {rf_fullcap_a.top_cor, rf_fullcap_a.base_cor, // 66:64
                         rf_fullcap_a.exp,                            // 63:59
                         rf_fullcap_a.top, rf_fullcap_a.base,         // 58:41
                         rf_fullcap_a.otype, rf_fullcap_a.cperms,     // 40:32
                         rf_rdata_a};                                 // 31:0
 
-  assign dbg_cs2_vec = {rf_fullcap_b.top_cor, rf_fullcap_b.base_cor, // 67:64
+  assign dbg_cs2_vec = {rf_fullcap_b.top_cor, rf_fullcap_b.base_cor, // 66:64
                         rf_fullcap_b.exp,                            // 63:59
                         rf_fullcap_b.top, rf_fullcap_b.base,         // 58:41
                         rf_fullcap_b.otype, rf_fullcap_b.cperms,     // 40:32
                         rf_rdata_b};                                 // 31:0
 
-  assign dbg_cd_vec = {result_cap_o.top_cor, result_cap_o.base_cor,  // 67:64
+  assign dbg_cd_vec = {result_cap_o.top_cor, result_cap_o.base_cor,  // 66:64
                         result_cap_o.exp,                            // 63:59
                         result_cap_o.top, result_cap_o.base,         // 58:41
                         result_cap_o.otype, result_cap_o.cperms,     // 40:32

--- a/rtl/cheri_pkg.sv
+++ b/rtl/cheri_pkg.sv
@@ -14,7 +14,7 @@ package cheri_pkg;
   parameter int unsigned CPERMS_W  = 6;
   parameter int unsigned PERMS_W   = 13;
 
-  parameter int unsigned REGCAP_W  = 38;
+  parameter int unsigned REGCAP_W  = 37;
 
   parameter bit    [4:0] RESETEXP  = 24;
   parameter int unsigned UPPER_W   = 24;
@@ -48,7 +48,7 @@ package cheri_pkg;
   typedef struct packed {
     logic                valid;
     logic [1:0]          top_cor;
-    logic [1:0]          base_cor;
+    logic                base_cor;
     logic [EXP_W-1   :0] exp;    // expanded
     logic [TOP_W-1   :0] top;
     logic [BOT_W-1   :0] base;
@@ -65,7 +65,7 @@ package cheri_pkg;
     logic [OTYPE_W-1 :0] otype;
     logic [PERMS_W-1: 0] perms;
     logic [1:0]          top_cor;
-    logic [1:0]          base_cor;
+    logic                base_cor;
     logic [TOP_W-1   :0] top;
     logic [BOT_W-1   :0] base;
     logic [CPERMS_W-1:0] cperms;
@@ -238,9 +238,9 @@ package cheri_pkg;
     return result;
   endfunction
 
-  // obtain 32-bit representation of top/base
-  function automatic logic[32:0] get_bound33(logic [TOP_W-1:0] top, logic [1:0]  cor,
-                                             logic [EXP_W-1:0] exp, logic [31:0] addr);
+  // obtain 32-bit representation of top
+  function automatic logic[32:0] get_top33(logic [TOP_W-1:0] top, logic [1:0]  cor,
+                                           logic [EXP_W-1:0] exp, logic [31:0] addr);
     logic [32:0] t1, t2, mask, cor_val;
 
     if (cor[1])
@@ -258,6 +258,12 @@ package cheri_pkg;
 
     return t1;
 
+  endfunction
+
+  // obtain 32-bit representation of base
+  function automatic logic[31:0] get_base32(logic [TOP_W-1:0] base, logic cor,
+                                            logic [EXP_W-1:0] exp, logic [31:0] addr);
+    return 32'(get_top33(base, cor ? 2'b11 : 2'b00, exp, addr));
   endfunction
 
   // this implementation give slightly better timing/area results
@@ -284,21 +290,21 @@ package cheri_pkg;
   endfunction
 
   // update the top/base correction for a cap
-  function automatic logic [3:0] update_temp_fields(logic [TOP_W-1:0] top, logic [BOT_W-1:0] base,
+  function automatic logic [2:0] update_temp_fields(logic [TOP_W-1:0] top, logic [BOT_W-1:0] base,
                                                     logic [BOT_W-1:0] addrmi);
     logic top_hi, addr_hi;
-    logic [3:0] res4;
+    logic [2:0] res3;
 
     top_hi   = (top < base);
     addr_hi  = (addrmi < base);
 
     // top_cor
-    res4[3:2] = (top_hi == addr_hi)? 2'b00 : ((top_hi && (!addr_hi))? 2'b01 : 2'b11);
+    res3[2:1] = (top_hi == addr_hi)? 2'b00 : ((top_hi && (!addr_hi))? 2'b01 : 2'b11);
 
     // base_cor
-    res4[1:0] = (addr_hi) ? 2'b11 : 0;
+    res3[0] = (addr_hi) ? 1 : 0;
 
-    return res4;
+    return res3;
   endfunction
 
   // set address of a capability
@@ -310,7 +316,7 @@ package cheri_pkg;
     full_cap_t        out_cap;
     logic [32:0]      tmp33;
     logic [32-TOP_W:0] tmp24, mask24;
-    logic  [3:0]      tmp4;
+    logic  [2:0]      tmp3;
     logic [BOT_W-1:0] ptrmi9;
     logic             top_lt;
 
@@ -325,9 +331,9 @@ package cheri_pkg;
       out_cap.valid = 1'b0;
 
     ptrmi9           = BOT_W'(newptr >> in_cap.exp);
-    tmp4             = update_temp_fields(out_cap.top, out_cap.base, ptrmi9);
-    out_cap.top_cor  = tmp4[3:2];
-    out_cap.base_cor = tmp4[1:0];
+    tmp3             = update_temp_fields(out_cap.top, out_cap.base, ptrmi9);
+    out_cap.top_cor  = tmp3[2:1];
+    out_cap.base_cor = tmp3[0];
 
     return out_cap;
   endfunction
@@ -447,7 +453,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     //   Note the new base == addr >> exp, so addr_hi == FALSE, thus base_cor == 0
     //   as such, top_cor can only be either either 0 or +1;
     out_cap.top_cor  = tophi ? 2'b00 : 2'b01;
-    out_cap.base_cor = 2'b00;
+    out_cap.base_cor = 1'b0;
 
     if (req_exact & (topoff | baseoff)) out_cap.valid = 1'b0;
 
@@ -515,8 +521,8 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     full_cap.cperms   = reg_cap.cperms;
     full_cap.rsvd     = reg_cap.rsvd;
 
-    full_cap.top33  = get_bound33(reg_cap.top, reg_cap.top_cor, reg_cap.exp, addr);
-    full_cap.base32 = 32'(get_bound33(reg_cap.base, reg_cap.base_cor, reg_cap.exp, addr));
+    full_cap.top33  = get_top33(reg_cap.top, reg_cap.top_cor, reg_cap.exp, addr);
+    full_cap.base32 = get_base32(reg_cap.base, reg_cap.base_cor, reg_cap.exp, addr);
     // full_cap  = update_bounds(full_cap, addr);   // for some reason this increases area 
 
     full_cap.maska    = 0;
@@ -559,7 +565,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     pcc_fullcap.otype    = in_pcap.otype;
     pcc_fullcap.perms    = in_pcap.perms;
     pcc_fullcap.top_cor  = 2'b0;          // will be updated by set_address()
-    pcc_fullcap.base_cor = 2'b0;
+    pcc_fullcap.base_cor = 1'b0;
     pcc_fullcap.top      = TOP_W'(in_pcap.top33  >> (in_pcap.exp));
     pcc_fullcap.base     = BOT_W'(in_pcap.base32 >> (in_pcap.exp));
     pcc_fullcap.cperms   = in_pcap.cperms;
@@ -615,7 +621,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
   function automatic reg_cap_t mem2regcap_fmt0 (logic [32:0] msw, logic [32:0] addr33, logic [3:0] clrperm);
     reg_cap_t regcap;
     logic [EXP_W-1:0] tmp5;
-    logic [3:0]  tmp4;
+    logic [2:0]  tmp3;
     logic [CPERMS_W-1:0] cperms_mem;
     logic [BOT_W-1:0]    addrmi9;
     logic                sealed;
@@ -636,9 +642,9 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     cperms_mem      = msw[CPERMS_LO+:CPERMS_W];
     regcap.cperms   = mask_clcperms(cperms_mem, clrperm, regcap.valid, sealed);
     addrmi9         = BOT_W'({1'b0, addr33[31:0]} >> regcap.exp); // ignore the tag valid bit
-    tmp4            = update_temp_fields(regcap.top, regcap.base, addrmi9);
-    regcap.top_cor  = tmp4[3:2];
-    regcap.base_cor = tmp4[1:0];
+    tmp3            = update_temp_fields(regcap.top, regcap.base, addrmi9);
+    regcap.top_cor  = tmp3[2:1];
+    regcap.base_cor = tmp3[0];
 
     regcap.rsvd     = msw[RSVD_LO];
 
@@ -670,7 +676,7 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
   function automatic reg_cap_t mem2regcap_fmt1 (logic [32:0] msw, logic [32:0] lsw, logic [3:0] clrperm);
     reg_cap_t regcap;
-    logic [3:0]  tmp4;
+    logic [2:0]  tmp3;
     logic        sealed;
     logic [8:0]  addrmi9;
     logic [CPERMS_W-1:0] cperms_mem;
@@ -692,9 +698,9 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     regcap.cperms = mask_clcperms(cperms_mem, clrperm, regcap.valid, sealed);
     regcap.rsvd   = lsw[31];
 
-    tmp4 = update_temp_fields(regcap.top, regcap.base, addrmi9);
-    regcap.top_cor  = tmp4[3:2];
-    regcap.base_cor = tmp4[1:0];
+    tmp3 = update_temp_fields(regcap.top, regcap.base, addrmi9);
+    regcap.top_cor  = tmp3[2:1];
+    regcap.base_cor = tmp3[0];
 
     return regcap;
 
@@ -759,8 +765,8 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
     logic [REGCAP_W-1:0] vec_out;
 
     vec_out[REGCAP_W-1]  = regcap.valid ;
-    vec_out[35+:2]       = regcap.top_cor;
-    vec_out[33+:2]       = regcap.base_cor;
+    vec_out[34+:2]       = regcap.top_cor;
+    vec_out[33+:1]       = regcap.base_cor;
     vec_out[28+:EXP_W]   = regcap.exp;
     vec_out[19+:TOP_W]   = regcap.top   ;
     vec_out[10+:BOT_W]   = regcap.base  ;
@@ -775,15 +781,15 @@ $display("--- set_bounds:  b1 = %x, t1 = %x, b2 = %x, t2 = %x", base1, top1, bas
 
     reg_cap_t regcap;
 
-    regcap.valid    = vec_in[REGCAP_W-1];  
-    regcap.top_cor  = vec_in[35+:2];       
-    regcap.base_cor = vec_in[33+:2];       
-    regcap.exp      = vec_in[28+:EXP_W];   
-    regcap.top      = vec_in[19+:TOP_W];   
-    regcap.base     = vec_in[10+:BOT_W];   
-    regcap.otype    = vec_in[7+:OTYPE_W];  
-    regcap.rsvd     = vec_in[6+:1];  
-    regcap.cperms   = vec_in[0+:CPERMS_W]; 
+    regcap.valid    = vec_in[REGCAP_W-1];
+    regcap.top_cor  = vec_in[34+:2];
+    regcap.base_cor = vec_in[33+:1];
+    regcap.exp      = vec_in[28+:EXP_W];
+    regcap.top      = vec_in[19+:TOP_W];
+    regcap.base     = vec_in[10+:BOT_W];
+    regcap.otype    = vec_in[7+:OTYPE_W];
+    regcap.rsvd     = vec_in[6+:1];
+    regcap.cperms   = vec_in[0+:CPERMS_W];
 
     return regcap;
   endfunction

--- a/rtl/cheri_stkz.sv
+++ b/rtl/cheri_stkz.sv
@@ -82,7 +82,7 @@ module cheri_stkz import cheri_pkg::*; (
 
 
   always_comb begin
-    logic [3:0] tmp4;
+    logic [2:0] tmp3;
     logic [8:0] addrmi9;
  
     if ((stkz_fsm_q == STKZ_IDLE) && stkz_start)
@@ -106,9 +106,9 @@ module cheri_stkz import cheri_pkg::*; (
     //   note we only start an zeroization if addr > base32 so no need for representability check
     ztop_rcap_nxt = ztop_rcap;
     addrmi9 = {stkz_ptrw_nxt, 2'b00} >> ztop_rcap.exp;
-    tmp4    = update_temp_fields(ztop_rcap.top, ztop_rcap.base, addrmi9);
-    ztop_rcap_nxt.top_cor  = tmp4[3:2];
-    ztop_rcap_nxt.base_cor = tmp4[1:0];
+    tmp3    = update_temp_fields(ztop_rcap.top, ztop_rcap.base, addrmi9);
+    ztop_rcap_nxt.top_cor  = tmp3[2:1];
+    ztop_rcap_nxt.base_cor = tmp3[0];
     ztop_rcap_nxt.valid    = ztop_rcap.valid & ~stkz_done;
   end
   

--- a/rtl/cheri_trvk_stage.sv
+++ b/rtl/cheri_trvk_stage.sv
@@ -55,7 +55,7 @@ module cheri_trvk_stage #(
   logic  [2:1] range_ok_q;
 
 
-  assign base32    = 32'(get_bound33(in_cap_q.base, in_cap_q.base_cor, in_cap_q.exp, in_data_q));
+  assign base32    = get_base32(in_cap_q.base, in_cap_q.base_cor, in_cap_q.exp, in_data_q);
   assign tsmap_ptr = (base32 - HeapBase) >> 3;
 
   assign tsmap_addr_o  = tsmap_ptr[15:5];


### PR DESCRIPTION
This saves one bit per register without any performance loss.