### PR TITLE
Add default parameters to fix build under Xcelium

### DIFF
--- a/rtl/cheri_ex.sv
+++ b/rtl/cheri_ex.sv
@@ -4,13 +4,13 @@
 
 module cheri_ex import cheri_pkg::*; #(
   parameter bit          WritebackStage = 1'b0,
-  parameter bit          MemCapFmt = 1'b0,
-  parameter int unsigned HeapBase,
-  parameter int unsigned TSMapBase,
-  parameter int unsigned TSMapSize,
-  parameter bit          CheriPPLBC  = 1'b1,
-  parameter bit          CheriSBND2  = 1'b0,
-  parameter bit          CheriStkZ   = 1'b1
+  parameter bit          MemCapFmt      = 1'b0,
+  parameter int unsigned HeapBase       = 32'h2001_0000,
+  parameter int unsigned TSMapBase      = 32'h2002_f000,
+  parameter int unsigned TSMapSize      = 1024,
+  parameter bit          CheriPPLBC     = 1'b1,
+  parameter bit          CheriSBND2     = 1'b0,
+  parameter bit          CheriStkZ      = 1'b1
 )(
    // Clock and Reset
   input  logic          clk_i,

--- a/rtl/cheri_trvk_stage.sv
+++ b/rtl/cheri_trvk_stage.sv
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module cheri_trvk_stage #(
-  parameter int unsigned HeapBase,
-  parameter int unsigned TSMapSize
+  parameter int unsigned HeapBase  = 32'h2001_0000,
+  parameter int unsigned TSMapSize = 1024
 ) (
    // Clock and Reset
   input  logic                clk_i,

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -50,9 +50,9 @@ module ibex_core import ibex_pkg::*; import cheri_pkg::*; #(
   // CHERIoT paramters
   parameter bit          CHERIoTEn         = 1'b1,
   parameter int unsigned DataWidth         = 33,
-  parameter int unsigned HeapBase          ,
-  parameter int unsigned TSMapBase         ,
-  parameter int unsigned TSMapSize         ,
+  parameter int unsigned HeapBase          = 32'h2001_0000,
+  parameter int unsigned TSMapBase         = 32'h2002_f000,
+  parameter int unsigned TSMapSize         = 1024,
   parameter bit          MemCapFmt         = 1'b0,
   parameter bit          CheriPPLBC        = 1'b1,
   parameter bit          CheriSBND2        = 1'b0,

--- a/rtl/ibex_lockstep.sv
+++ b/rtl/ibex_lockstep.sv
@@ -38,9 +38,9 @@ module ibex_lockstep import ibex_pkg::*; import cheri_pkg::*; #(
   // CHERIoT paramters
   parameter bit          CHERIoTEn         = 1'b1,
   parameter int unsigned DataWidth         = 33,
-  parameter int unsigned HeapBase          ,
-  parameter int unsigned TSMapBase         ,
-  parameter int unsigned TSMapSize         ,
+  parameter int unsigned HeapBase          = 32'h2001_0000,
+  parameter int unsigned TSMapBase         = 32'h2002_f000,
+  parameter int unsigned TSMapSize         = 1024,
   parameter bit          MemCapFmt         = 1'b0,
   parameter bit          CheriPPLBC        = 1'b1,
   parameter bit          CheriSBND2        = 1'b0,


### PR DESCRIPTION
Xcelium won't build a simulation without this fix.

The default parameters are the same as those in https://github.com/microsoft/cheriot-ibex/blob/main/rtl/ibex_top.sv