### PR TITLE
Regression fixes to formal verification code.

### DIFF
--- a/dv/formal/check/peek/mem.sv
+++ b/dv/formal/check/peek/mem.sv
@@ -135,8 +135,8 @@ alt_lsu #(.CHERIoTEn(1'b1), .MemCapFmt(1'b0), .CheriTBRE(1'b0)) alt_lsu_very_ear
             {spec_mem_read_tag, spec_mem_read_snd_rdata}
     ),
     `ALT_LSU_STATE_COPY
-    .data_type_q(`LSU.lsu_type_i),
-    .data_sign_ext_q(`LSU.lsu_sign_ext_i),
+    .data_type_q(`LSU.cpu_lsu_type_i),
+    .data_sign_ext_q(`LSU.cpu_lsu_sign_ext_i),
     .rdata_offset_q(`LSU.data_offset),
     .rdata_q(spec_mem_read_fst_rdata[31:8]),
     .cap_lsw_q({spec_mem_read_tag, spec_mem_read_fst_rdata})

--- a/dv/formal/check/top.sv
+++ b/dv/formal/check/top.sv
@@ -302,7 +302,7 @@ logic mem_resp_q; // We have had an rvalid for EX
 logic wbexc_mem_had_snd_req; // During ID/EX there was a second request
 
 logic lsu_had_first_resp;
-assign lsu_had_first_resp = (`LSU.ls_fsm_cs == `LSU.WAIT_GNT && `LSU.split_misaligned_access) || (`LSU.lsu_is_cap_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP2);
+assign lsu_had_first_resp = (`LSU.ls_fsm_cs == `LSU.WAIT_GNT && `LSU.split_misaligned_access) || (`LSU.cpu_lsu_is_cap_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP2);
 
 ////////////////////// Wrap signals //////////////////////
 

--- a/dv/formal/thm/ibex.proof
+++ b/dv/formal/thm/ibex.proof
@@ -138,7 +138,7 @@ lemma ibex
     LSUEnd: have (`LSU.lsu_req_done_o |-> instr_will_progress)
     LSUNotTRSV: have (`LSU.ls_fsm_cs != `LSU.IDLE |-> ~`ID.stall_cheri_trvk)
 
-  NoTBRE: have (~`CE.lsu_tbre_sel_i & ~`LSU.req_is_tbre_q & ~`LSU.tbre_req_good & ~`CR.tbre_lsu_req)
+  NoTBRE: have (~`CR.lsu_tbre_sel_i & ~`LSU.req_is_tbre_q & ~`LSU.tbre_req_good & ~`CR.tbre_lsu_req)
 
   /
 
@@ -155,40 +155,40 @@ lemma ibex
       (`LSU.cap_rx_fsm_q == CRX_IDLE || (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP2 && data_rvalid_i))
     )
     inv wait_gnt_mis (
-      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.lsu_cheri_err_i &&
+      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i &&
       `LSU.cap_rx_fsm_q == CRX_IDLE && ~ex_is_mem_cap_instr
     )
     inv wait_gnt (
-      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.lsu_cheri_err_i &&
+      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i &&
       `LSU.cap_rx_fsm_q == CRX_IDLE && ~ex_is_mem_cap_instr
     )
     inv wait_rvalid_mis (
       ($stable(`LSU.ls_fsm_cs) -> $stable(data_addr_o)) &&
-      has_one_resp_waiting_q && ~`LSU.lsu_cheri_err_i &&
+      has_one_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i &&
       `LSU.cap_rx_fsm_q == CRX_IDLE && ~ex_is_mem_cap_instr
     )
     inv wait_rvalid_mis_gnts_done (
       $stable(data_addr_o) &&
-      has_two_resp_waiting_q && ~`LSU.lsu_cheri_err_i &&
+      has_two_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i &&
       `LSU.cap_rx_fsm_q == CRX_IDLE && ~ex_is_mem_cap_instr &&
       ~`LSU.handle_misaligned_q
     )
     inv wait_gnt1 (
-      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
+      $stable(data_addr_o) && ~has_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
       ~`LSU.handle_misaligned_q
     )
     inv wait_gnt2 (
       ($stable(`LSU.ls_fsm_cs) -> $stable(data_addr_o)) &&
-      has_one_resp_waiting_q && ~`LSU.lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
+      has_one_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
       ~`LSU.handle_misaligned_q
     )
     inv wait_gnt2_direct (
       ($stable(`LSU.ls_fsm_cs) -> $stable(data_addr_o)) &&
-      ~has_resp_waiting_q && ~`LSU.lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP2 && ex_is_mem_cap_instr &&
+      ~has_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP2 && ex_is_mem_cap_instr &&
       ~`LSU.handle_misaligned_q
     )
     inv wait_resp (
-      $stable(data_addr_o) && has_two_resp_waiting_q && ~`LSU.lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
+      $stable(data_addr_o) && has_two_resp_waiting_q && ~`LSU.cpu_lsu_cheri_err_i && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ex_is_mem_cap_instr &&
       ~`LSU.handle_misaligned_q
     )
 
@@ -201,7 +201,7 @@ lemma ibex
       ~`LSU.handle_misaligned_d
     )
     inv wait (
-      outstanding_mem && has_one_resp_waiting_q && ~`LSU.lsu_req_i && wbexc_exists &&
+      outstanding_mem && has_one_resp_waiting_q && ~`LSU.cpu_lsu_req_i && wbexc_exists &&
       (wbexc_is_mem_cap_instr -> (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP2)) &&
       (~wbexc_is_mem_cap_instr -> (`LSU.cap_rx_fsm_q == CRX_IDLE)) &&
       ~`LSU.handle_misaligned_q && ~`LSU.cheri_err_q
@@ -219,7 +219,7 @@ lemma ibex
     edge idle => idle
     edge idle -> idle_active
     
-    node idle_active idle_active (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req && ~`CR.lsu_cheri_err)
+    node idle_active idle_active (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err)
     edge idle_active => wait_rvalid_mis wait_gnt_mis wait_gnt wait_gnt1 wait_gnt2
     edge idle_active -> step
     
@@ -254,7 +254,7 @@ lemma ibex
     edge wait_resp => wait_resp
     edge wait_resp -> step
 
-    node step step (`LSU.lsu_req_done_o & ~`LSU.lsu_cheri_err_i)
+    node step step (`LSU.lsu_req_done_o & ~`LSU.cpu_lsu_cheri_err_i)
     edge step => wait end
     
     node wait wait (has_resp_waiting_q && ~`CR.lsu_resp_valid && `LSU.ls_fsm_cs == `LSU.IDLE && ~instr_will_progress)
@@ -264,14 +264,14 @@ lemma ibex
     edge end -> idle
   /
   NoMemAccessNoRValid: have (`LSU.lsu_resp_valid_o -> outstanding_mem)
-  StallNoChangeA: have (`LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(`ID.rf_rdata_a_fwd) & $stable(`CE.rf_rcap_a))
-  StallNoChangeB: have (data_we_o && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(`ID.rf_rdata_b_fwd) & $stable(`CE.rf_rcap_a))
+  StallNoChangeA: have (`LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(`ID.rf_rdata_a_fwd) & $stable(`CE.rf_rcap_a))
+  StallNoChangeB: have (data_we_o && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(`ID.rf_rdata_b_fwd) & $stable(`CE.rf_rcap_a))
 
   BecameDecodeIsInstrStart: have (`IDC.ctrl_fsm_cs == `IDC.DECODE && !$stable(`IDC.ctrl_fsm_cs) |-> ~`ID.instr_valid_i | `CR.instr_new_id)
   BecameDecodeIsEmptyWbexc: have (`IDC.ctrl_fsm_cs == `IDC.DECODE && !$stable(`IDC.ctrl_fsm_cs) |-> ~wbexc_exists)
   FetchErrIsErr: have (wbexc_fetch_err & wbexc_exists |-> wbexc_err & `IDC.instr_fetch_err)
 
-  MemOpRequiresValid: have (`LSU.ls_fsm_cs != `LSU.IDLE || `CR.lsu_req |-> `ID.instr_valid_i)
+  MemOpRequiresValid: have (`LSU.ls_fsm_cs != `LSU.IDLE || `CR.cpu_lsu_req |-> `ID.instr_valid_i)
 
   MultEndState: have (instr_will_progress |=> `MULTG.mult_state_q == `MULTG.ALBL)
 
@@ -293,26 +293,26 @@ lemma ibex
   StallIdFSM2: have (`ID.instr_executing && ~instr_will_progress |=> `ID.instr_executing)
   NewIdFSM: have (`CR.instr_new_id |-> `ID.id_fsm_q == 0)
   PreNextPcMatch: have (instr_will_progress & ~ex_has_branched_d & ~`IDC.instr_fetch_err -> pre_nextpc == `CR.pc_if)
-  StallNoChangeLsuWData: have ((data_we_o && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(`LSU.lsu_wdata_i)))
+  StallNoChangeLsuWData: have ((data_we_o && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(`LSU.cpu_lsu_wdata_i)))
 
   # These properties take some time to prove, but do prove with low proof effort
-  SpecStableLoad: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_read))
-  SpecStableLoadSnd: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_read_snd))
-  SpecStableLoadAddr: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_read_fst_addr))
-  SpecStableLoadSndAddr: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_read_snd_addr))
+  SpecStableLoad: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_read))
+  SpecStableLoadSnd: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_read_snd))
+  SpecStableLoadAddr: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_read_fst_addr))
+  SpecStableLoadSndAddr: have (ex_is_load_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_read_snd_addr))
 
-  SpecStableStore: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write))
-  SpecStableStoreSnd: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write_snd))
-  SpecStableStoreAddr: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write_fst_addr))
-  SpecStableStoreSndAddr: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write_snd_addr))
-  SpecStableStoreData: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write_fst_wdata))
-  SpecStableStoreSndData: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.lsu_req_i)) |-> $stable(spec_mem_write_snd_wdata))
+  SpecStableStore: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write))
+  SpecStableStoreSnd: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write_snd))
+  SpecStableStoreAddr: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write_fst_addr))
+  SpecStableStoreSndAddr: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write_snd_addr))
+  SpecStableStoreData: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write_fst_wdata))
+  SpecStableStoreSndData: have (ex_is_store_instr && `LSU.ls_fsm_cs != `LSU.IDLE && ($past(`LSU.ls_fsm_cs) != `LSU.IDLE || $past(`LSU.cpu_lsu_req_i)) |-> $stable(spec_mem_write_snd_wdata))
 
   LoadNotSpecWrite: have (ex_is_load_instr |-> ~spec_mem_write)
   StoreNotSpecRead: have (ex_is_store_instr |-> ~spec_mem_read)
 
   FirstCycleNoGnt: have (`ID.instr_first_cycle |-> ~mem_gnt_fst_q)
-  MemStartFirstCycle: have (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req |-> `ID.instr_first_cycle)
+  MemStartFirstCycle: have (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req |-> `ID.instr_first_cycle)
   DivInstrStable: have (`MULT.md_state_q != `MULT.MD_IDLE |-> $stable(`CR.instr_rdata_id) && `CR.instr_valid_id && (~`ID.stall_multdiv -> `MULT.md_state_q == `MULT.MD_FINISH) && `MULTG.mult_state_q == `MULTG.ALBL && `MULT.div_en_internal && (~wbexc_exists | wbexc_finishing))
 
   InstrReqCount: have (
@@ -341,7 +341,7 @@ lemma ibex
   NoStallBranch: have (`ID.instr_valid_i & `ID.stall_id & ~`ID.branch_set_raw & ~`ID.jump_set_raw & ~`IDC.cheri_branch_req_i |-> ~ex_has_branched_d)
   FirstCycleHold: have (`ID.instr_valid_i & ~`ID.instr_executing |-> `ID.id_fsm_q == `ID.FIRST_CYCLE)
 
-  ReqNotOutstanding: have (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req |-> ~`LSU.resp_wait)
+  ReqNotOutstanding: have (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req |-> ~`LSU.resp_wait)
   /
   SpecEnUnreach: have (spec_en |-> ~spec_int_err)
 

--- a/dv/formal/thm/ibex.proof
+++ b/dv/formal/thm/ibex.proof
@@ -138,7 +138,7 @@ lemma ibex
     LSUEnd: have (`LSU.lsu_req_done_o |-> instr_will_progress)
     LSUNotTRSV: have (`LSU.ls_fsm_cs != `LSU.IDLE |-> ~`ID.stall_cheri_trvk)
 
-  NoTBRE: have (~`CR.lsu_tbre_sel_i & ~`LSU.req_is_tbre_q & ~`LSU.tbre_req_good & ~`CR.tbre_lsu_req)
+  NoTBRE: have (~`LSU.req_is_tbre_q & ~`LSU.tbre_req_good & ~`CR.tbre_lsu_req)
 
   /
 

--- a/dv/formal/thm/mem.proof
+++ b/dv/formal/thm/mem.proof
@@ -8,7 +8,7 @@ lemma mem
   MemNotWFI: have (wbexc_exists && wbexc_is_mem_instr |-> ~wbexc_is_wfi)
   MemFin: have (finishing_executed && wbexc_is_mem_instr && ~wbexc_err |-> data_rvalid_i)
 
-  RespWait: have (wbexc_exists && wbexc_is_mem_instr && ~wbexc_err && ~data_rvalid_i |-> `LSU.ls_fsm_cs == `LSU.IDLE && ~`LSU.lsu_req_i)
+  RespWait: have (wbexc_exists && wbexc_is_mem_instr && ~wbexc_err && ~data_rvalid_i |-> `LSU.ls_fsm_cs == `LSU.IDLE && ~`LSU.cpu_lsu_req_i)
 
   CapResp: have (`LSU.ls_fsm_cs != `LSU.IDLE || (outstanding_mem & ~wbexc_err) || data_rvalid_i |->
     ((wbexc_exists && ~wbexc_err && (`IS_LOADCAPIMM | `IS_STORECAPIMM)) || (`LSU.ls_fsm_cs != `LSU.IDLE && ex_is_mem_cap_instr)) == `LSU.resp_is_cap_q
@@ -17,11 +17,11 @@ lemma mem
   
   EarlyLSUCtrlMatch: have (
     `LSU.ls_fsm_cs != `LSU.IDLE & spec_post_wX_en & mem_gnt_fst_q |->
-    `LSU.rdata_offset_q == `LSU.data_offset && `LSU.data_type_q == `LSU.lsu_type_i && `LSU.data_sign_ext_q == `LSU.lsu_sign_ext_i && `LSU.data_we_q == `LSU.lsu_we_i
+    `LSU.rdata_offset_q == `LSU.data_offset && `LSU.data_type_q == `LSU.cpu_lsu_type_i && `LSU.data_sign_ext_q == `LSU.cpu_lsu_sign_ext_i && `LSU.data_we_q == `LSU.cpu_lsu_we_i
   )
 
-  HadSndReqCap: have (instr_will_progress & ex_is_mem_cap_instr & ~ex_err & ~`LSU.lsu_cheri_err_i |=> wbexc_mem_had_snd_req)
-  HadSndReqNotCap: have (instr_will_progress & ex_is_mem_instr & ~ex_is_mem_cap_instr & ~ex_err & ~`LSU.lsu_cheri_err_i |=> wbexc_mem_had_snd_req == $past(`LSU.split_misaligned_access))
+  HadSndReqCap: have (instr_will_progress & ex_is_mem_cap_instr & ~ex_err & ~`LSU.cpu_lsu_cheri_err_i |=> wbexc_mem_had_snd_req)
+  HadSndReqNotCap: have (instr_will_progress & ex_is_mem_instr & ~ex_is_mem_cap_instr & ~ex_err & ~`LSU.cpu_lsu_cheri_err_i |=> wbexc_mem_had_snd_req == $past(`LSU.split_misaligned_access))
 
   LateLSUCheriErr: have (wbexc_exists & wbexc_is_load_instr & ~wbexc_err & wbexc_post_wX_en |-> ~`LSU.cheri_err_q)
 
@@ -33,43 +33,43 @@ lemma mem
 
 
   CapFsm: graph_induction
-    cond (ex_is_mem_cap_instr && (`LSU.ls_fsm_cs != `LSU.IDLE || (`CR.lsu_req && ~`CR.lsu_cheri_err)))
+    cond (ex_is_mem_cap_instr && (`LSU.ls_fsm_cs != `LSU.IDLE || (`CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err)))
 
-    entry (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req && ~`CR.lsu_cheri_err) -> idle_active
+    entry (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err) -> idle_active
 
-    node idle_active (`LSU.cap_rx_fsm_q == CRX_IDLE || (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP2 && data_rvalid_i)) (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req && ~`CR.lsu_cheri_err)
+    node idle_active (`LSU.cap_rx_fsm_q == CRX_IDLE || (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP2 && data_rvalid_i)) (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err)
     edge idle_active => wait_gnt1 wait_gnt2 wait_gnt2_done
 
-    node wait_gnt1 (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ~`CR.lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT1)
+    node wait_gnt1 (`LSU.cap_rx_fsm_q == CRX_WAIT_RESP1 && ~`CR.cpu_lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT1)
     edge wait_gnt1 => wait_gnt1 wait_gnt2 wait_gnt2_done
 
-    node wait_gnt2 (~`CR.lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT2 && `LSU.cap_rx_fsm_d == CRX_WAIT_RESP1)
+    node wait_gnt2 (~`CR.cpu_lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT2 && `LSU.cap_rx_fsm_d == CRX_WAIT_RESP1)
     edge wait_gnt2 => wait_gnt2 wait_gnt2_done wait_resp
     edge wait_gnt2 -> step
 
     # waitgnt2done step is bound dependent (Hp (12))
-    node wait_gnt2_done (~`CR.lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT2 && `LSU.cap_rx_fsm_d == CRX_WAIT_RESP2)
+    node wait_gnt2_done (~`CR.cpu_lsu_cheri_err) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_GNT2 && `LSU.cap_rx_fsm_d == CRX_WAIT_RESP2)
     edge wait_gnt2_done => wait_gnt2_done
     edge wait_gnt2_done -> step
 
-    node wait_resp (~`CR.lsu_cheri_err && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_RESP)
+    node wait_resp (~`CR.cpu_lsu_cheri_err && `LSU.cap_rx_fsm_q == CRX_WAIT_RESP1) (`LSU.ls_fsm_cs == `LSU.CTX_WAIT_RESP)
     edge wait_resp => wait_resp
     edge wait_resp -> step
 
-    node step (`LSU.cap_rx_fsm_d == CRX_WAIT_RESP2) (`LSU.lsu_req_done_o && ~`CR.lsu_cheri_err) +exit
+    node step (`LSU.cap_rx_fsm_d == CRX_WAIT_RESP2) (`LSU.lsu_req_done_o && ~`CR.cpu_lsu_cheri_err) +exit
 
   MemSpec: graph_induction +rev
-    cond (ex_is_mem_instr && (`LSU.ls_fsm_cs != `LSU.IDLE || (`CR.lsu_req && ~`CR.lsu_cheri_err)))
+    cond (ex_is_mem_instr && (`LSU.ls_fsm_cs != `LSU.IDLE || (`CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err)))
 
-    inv fst_req (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.lsu_cheri_err)
-    inv fst_req_1 (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.lsu_cheri_err && ~spec_mem_read_snd && ~spec_mem_write_snd)
-    inv fst_req_2 (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.lsu_cheri_err && (spec_mem_read_snd | spec_mem_write_snd))
-    inv snd_req (mem_req_snd_d && snd_mem_cmp && ~`CR.lsu_cheri_err && (spec_mem_read_snd | spec_mem_write_snd))
-    inv req_done (~data_req_o && ~`CR.lsu_cheri_err && mem_gnt_snd_q && (spec_mem_read_snd | spec_mem_write_snd))
+    inv fst_req (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.cpu_lsu_cheri_err)
+    inv fst_req_1 (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.cpu_lsu_cheri_err && ~spec_mem_read_snd && ~spec_mem_write_snd)
+    inv fst_req_2 (mem_req_fst_d && fst_mem_cmp && ~mem_gnt_fst_q && ~`CR.cpu_lsu_cheri_err && (spec_mem_read_snd | spec_mem_write_snd))
+    inv snd_req (mem_req_snd_d && snd_mem_cmp && ~`CR.cpu_lsu_cheri_err && (spec_mem_read_snd | spec_mem_write_snd))
+    inv req_done (~data_req_o && ~`CR.cpu_lsu_cheri_err && mem_gnt_snd_q && (spec_mem_read_snd | spec_mem_write_snd))
 
-    entry (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req && ~`CR.lsu_cheri_err) -> idle_active
+    entry (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err) -> idle_active
 
-    node idle_active fst_req (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.lsu_req && ~`CR.lsu_cheri_err)
+    node idle_active fst_req (`LSU.ls_fsm_cs == `LSU.IDLE && `CR.cpu_lsu_req && ~`CR.cpu_lsu_cheri_err)
     edge idle_active => wait_rvalid_mis wait_gnt_mis wait_gnt wait_gnt1 wait_gnt2
     edge idle_active -> step
     
@@ -104,7 +104,7 @@ lemma mem
     edge wait_resp => wait_resp
     edge wait_resp -> step
 
-    node step (1) (`LSU.lsu_req_done_o && ~`CR.lsu_cheri_err) +exit
+    node step (1) (`LSU.lsu_req_done_o && ~`CR.cpu_lsu_cheri_err) +exit
   /
   LSULateRespFinishing: have (late_resp |-> wbexc_finishing || wbexc_err)
   LSUEarlyRequestSplit: have (early_resp |-> has_snd_req)
@@ -117,7 +117,7 @@ lemma mem
   NoMem: have (~ex_is_mem_instr & instr_will_progress |-> ~mem_gnt_fst_d)
 
   AltLSUVeryEarly: have (`LSU.ls_fsm_cs != `LSU.IDLE & spec_post_wX_en & ~lsu_had_first_resp |-> alas(spec_post_wX, revoke(alt_lsu_very_early_res, spec_mem_revoke_en & spec_mem_revoke)))
-  ExceptionMaintain: have (`LSU.lsu_req_i && ~spec_mem_read & ~spec_mem_write |-> instr_will_progress ##1 wbexc_err)
+  ExceptionMaintain: have (`LSU.cpu_lsu_req_i && ~spec_mem_read & ~spec_mem_write |-> instr_will_progress ##1 wbexc_err)
   FastErrSignalCap: have (finishing_executed & ~wbexc_illegal & wbexc_err & (`IS_LOADCAPIMM | `IS_STORECAPIMM) |->
     ($past(`CE.is_load_cap, 2) | $past(`CE.is_store_cap, 2)) & $past(`CE.cheri_lsu_err, 2) & $past(`CE.cheri_exec_id_i, 2)
   )


### PR DESCRIPTION
Commit ccd80d3 changed the names of a number of signals, which broke the formal verification. In addition, the signal `CR.lsu_tbre_sel_i had been removed, so an assertion about this had to be taken out of the proof. This contribution aligns the verification code to these changes.