### PR TITLE
MISA value RV32E set dynamically when in CHERIoT

### DIFF
--- a/rtl/ibex_cs_registers.sv
+++ b/rtl/ibex_cs_registers.sv
@@ -333,8 +333,16 @@ module ibex_cs_registers import cheri_pkg::*;  #(
 
   logic [31:0] misa_value_masked;
 
-  assign misa_value_masked = MISA_VALUE & ~{8'h0, ~cheri_pmode_i, 23'h0};
-
+  // Set the X, I and E bits dynamically based on cheri_pmode_i.
+  // I must always be the complement of E.
+  assign misa_value_masked = {MISA_VALUE[31:24],
+                              CHERIoTEn ? cheri_pmode_i : MISA_VALUE[23], // X
+                              MISA_VALUE[22:9],
+                              CHERIoTEn ? ~cheri_pmode_i : MISA_VALUE[8], // I
+                              MISA_VALUE[7:5],
+                              CHERIoTEn ? cheri_pmode_i : MISA_VALUE[4], // E
+                              MISA_VALUE[3:0]
+                             };
 
   /////////////
   // CSR reg //


### PR DESCRIPTION
Both the X bit and the E bit need to be set in the MISA CSR when CHERIoT is enabled.

Debuggers use this information to determine how many architectural registers there are.